### PR TITLE
Fix business owner stats

### DIFF
--- a/src/people/people.types.ts
+++ b/src/people/people.types.ts
@@ -48,6 +48,7 @@ export type PerformanceFieldKey = Extract<
 export type PrismaVoterScalarStringKeys = Extract<
   keyof Prisma.VoterWhereInput,
   | 'Homeowner_Probability_Model'
+  | 'Business_Owner'
   | 'Estimated_Income_Amount'
   | 'Education_Of_Person'
   | 'Presence_Of_Children'
@@ -89,6 +90,7 @@ export type StringMapper<Label extends string> = (
 export interface StatsCategoryMap {
   age?: BucketsResult
   homeowner?: BucketsWithRaw
+  businessOwner?: BucketsWithRaw
   income?: BucketsResult
   education?: BucketsResult
   familyChildren?: BucketsResult

--- a/src/people/services/stats.service.ts
+++ b/src/people/services/stats.service.ts
@@ -12,6 +12,7 @@ import {
   mergeTopNWithOther,
   normalizeChildrenPresence,
   normalizeEducationBucket,
+  normalizeBusinessOwner,
   normalizeHomeowner,
   normalizeIncomeBucket,
 } from 'src/shared/util/stats'
@@ -216,6 +217,16 @@ export class StatsService extends createPrismaBase(MODELS.Voter) {
           'Marital_Status',
           totalConstituents,
           topN,
+        ),
+      )
+    if (wants('businessOwner'))
+      pushTask('businessOwner', () =>
+        this.computeMappedStringBuckets(
+          where,
+          'Business_Owner',
+          totalConstituents,
+          (v) => normalizeBusinessOwner(v),
+          { forceYesNoUnknown: true, includeRawDistribution: true },
         ),
       )
 

--- a/src/shared/util/stats.ts
+++ b/src/shared/util/stats.ts
@@ -37,6 +37,17 @@ export const normalizeChildrenPresence = (
   return 'Unknown'
 }
 
+export const normalizeBusinessOwner = (
+  value: string | null | undefined,
+): 'Yes' | 'No' | 'Unknown' => {
+  const v = (value || '').trim().toLowerCase()
+  if (!v) return 'Unknown'
+  // If the data vendor ever provides explicit negatives, treat them as No
+  if (v === 'n' || v === 'no' || v === 'false') return 'No'
+  // Any other non-empty value indicates some form of ownership/employment
+  return 'Yes'
+}
+
 export const normalizeIncomeBucket = (
   value: string | null | undefined,
 ):


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a `businessOwner` stats facet using `Business_Owner` with Yes/No/Unknown normalization and raw breakdown.
> 
> - **Stats**:
>   - Add `businessOwner` category in `src/people/services/stats.service.ts`, computing mapped buckets from `Business_Owner` via `computeMappedStringBuckets` with `normalizeBusinessOwner`, forcing Yes/No/Unknown and including raw distribution.
> - **Types**:
>   - Extend `PrismaVoterScalarStringKeys` with `Business_Owner` and `StatsCategoryMap` with `businessOwner` in `src/people/people.types.ts`.
> - **Utils**:
>   - Implement `normalizeBusinessOwner` in `src/shared/util/stats.ts` to map values to `Yes`/`No`/`Unknown`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d9eb42b5f46cd2df26a214a71df89d228b8a43ca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->