### PR TITLE
another fix attempt

### DIFF
--- a/deploy/sst.config.ts
+++ b/deploy/sst.config.ts
@@ -168,7 +168,7 @@ export default $config({
         preferredBackupWindow: '07:00-09:00',
         storageEncrypted: true,
         skipFinalSnapshot: isDevelop ? true : undefined,
-        databaseInsightsMode: 'advanced'
+        databaseInsightsMode: 'advanced',
       })
       const instanceCount = isProd ? 2 : 1
       for (let i = 0; i < instanceCount; i++) {
@@ -200,7 +200,7 @@ export default $config({
             timeout: '10 seconds',
             healthyThreshold: 2,
             unhealthyThreshold: 5,
-            gracePeriod: '300 seconds',
+            gracePeriod: '900 seconds',
           },
         },
       },

--- a/prisma/migrations/20250917185213_demographic_indexes/migration.sql
+++ b/prisma/migrations/20250917185213_demographic_indexes/migration.sql
@@ -1,32 +1,32 @@
 -- CreateIndex
-CREATE INDEX "Voter_Business_Owner_idx" ON "Voter"("Business_Owner");
+CREATE INDEX CONCURRENTLY "Voter_Business_Owner_idx" ON "Voter"("Business_Owner");
 
 -- CreateIndex
-CREATE INDEX "Voter_Education_Of_Person_idx" ON "Voter"("Education_Of_Person");
+CREATE INDEX CONCURRENTLY "Voter_Education_Of_Person_idx" ON "Voter"("Education_Of_Person");
 
 -- CreateIndex
-CREATE INDEX "Voter_Estimated_Income_Amount_idx" ON "Voter"("Estimated_Income_Amount");
+CREATE INDEX CONCURRENTLY "Voter_Estimated_Income_Amount_idx" ON "Voter"("Estimated_Income_Amount");
 
 -- CreateIndex
-CREATE INDEX "Voter_Homeowner_Probability_Model_idx" ON "Voter"("Homeowner_Probability_Model");
+CREATE INDEX CONCURRENTLY "Voter_Homeowner_Probability_Model_idx" ON "Voter"("Homeowner_Probability_Model");
 
 -- CreateIndex
-CREATE INDEX "Voter_Language_Code_idx" ON "Voter"("Language_Code");
+CREATE INDEX CONCURRENTLY "Voter_Language_Code_idx" ON "Voter"("Language_Code");
 
 -- CreateIndex
-CREATE INDEX "Voter_Marital_Status_idx" ON "Voter"("Marital_Status");
+CREATE INDEX CONCURRENTLY "Voter_Marital_Status_idx" ON "Voter"("Marital_Status");
 
 -- CreateIndex
-CREATE INDEX "Voter_Presence_Of_Children_idx" ON "Voter"("Presence_Of_Children");
+CREATE INDEX CONCURRENTLY "Voter_Presence_Of_Children_idx" ON "Voter"("Presence_Of_Children");
 
 -- CreateIndex
-CREATE INDEX "Voter_Registered_Voter_idx" ON "Voter"("Registered_Voter");
+CREATE INDEX CONCURRENTLY "Voter_Registered_Voter_idx" ON "Voter"("Registered_Voter");
 
 -- CreateIndex
-CREATE INDEX "Voter_Veteran_Status_idx" ON "Voter"("Veteran_Status");
+CREATE INDEX CONCURRENTLY "Voter_Veteran_Status_idx" ON "Voter"("Veteran_Status");
 
 -- CreateIndex
-CREATE INDEX "Voter_Voter_Status_idx" ON "Voter"("Voter_Status");
+CREATE INDEX CONCURRENTLY "Voter_Voter_Status_idx" ON "Voter"("Voter_Status");
 
 -- CreateIndex
-CREATE INDEX "Voter_Voter_Status_UpdatedAt_idx" ON "Voter"("Voter_Status_UpdatedAt");
+CREATE INDEX CONCURRENTLY "Voter_Voter_Status_UpdatedAt_idx" ON "Voter"("Voter_Status_UpdatedAt");

--- a/prisma/migrations/20250922154402_more_demographic_indices/migration.sql
+++ b/prisma/migrations/20250922154402_more_demographic_indices/migration.sql
@@ -1,14 +1,14 @@
 -- CreateIndex
-CREATE INDEX "Voter_Precinct_idx" ON "Voter"("Precinct");
+CREATE INDEX CONCURRENTLY "Voter_Precinct_idx" ON "Voter"("Precinct");
 
 -- CreateIndex
-CREATE INDEX "Voter_Age_Int_idx" ON "Voter"("Age_Int");
+CREATE INDEX CONCURRENTLY "Voter_Age_Int_idx" ON "Voter"("Age_Int");
 
 -- CreateIndex
-CREATE INDEX "Voter_VoterTelephones_CellPhoneFormatted_idx" ON "Voter"("VoterTelephones_CellPhoneFormatted");
+CREATE INDEX CONCURRENTLY "Voter_VoterTelephones_CellPhoneFormatted_idx" ON "Voter"("VoterTelephones_CellPhoneFormatted");
 
 -- CreateIndex
-CREATE INDEX "Voter_VoterTelephones_LandlineFormatted_idx" ON "Voter"("VoterTelephones_LandlineFormatted");
+CREATE INDEX CONCURRENTLY "Voter_VoterTelephones_LandlineFormatted_idx" ON "Voter"("VoterTelephones_LandlineFormatted");
 
 -- CreateIndex
-CREATE INDEX "Voter_EthnicGroups_EthnicGroup1Desc_idx" ON "Voter"("EthnicGroups_EthnicGroup1Desc");
+CREATE INDEX CONCURRENTLY "Voter_EthnicGroups_EthnicGroup1Desc_idx" ON "Voter"("EthnicGroups_EthnicGroup1Desc");


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Make voter index creation concurrent and increase LB health check grace period from 300s to 900s.
> 
> - **Database (Prisma migrations)**:
>   - Switch multiple `Voter` table index creations to `CREATE INDEX CONCURRENTLY` across `20250917185213_demographic_indexes` and `20250922154402_more_demographic_indices`.
> - **Infra (`deploy/sst.config.ts`)**:
>   - Increase load balancer health check `gracePeriod` on `80/http` from `300 seconds` to `900 seconds`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7782f0462c5f234a586bad9994a8e4db6e65289c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->