### PR TITLE
chore: fix-build4

### DIFF
--- a/prisma/migrations/20250930000000_recreate_demographic_indices_concurrently/migration.sql
+++ b/prisma/migrations/20250930000000_recreate_demographic_indices_concurrently/migration.sql
@@ -1,46 +1,22 @@
--- Drop existing non-concurrent indexes from 20250917185213_demographic_indexes
-DROP INDEX IF EXISTS "Voter_Business_Owner_idx";
-DROP INDEX IF EXISTS "Voter_Education_Of_Person_idx";
-DROP INDEX IF EXISTS "Voter_Estimated_Income_Amount_idx";
-DROP INDEX IF EXISTS "Voter_Homeowner_Probability_Model_idx";
-DROP INDEX IF EXISTS "Voter_Language_Code_idx";
-DROP INDEX IF EXISTS "Voter_Marital_Status_idx";
-DROP INDEX IF EXISTS "Voter_Presence_Of_Children_idx";
-DROP INDEX IF EXISTS "Voter_Registered_Voter_idx";
-DROP INDEX IF EXISTS "Voter_Veteran_Status_idx";
-DROP INDEX IF EXISTS "Voter_Voter_Status_idx";
-DROP INDEX IF EXISTS "Voter_Voter_Status_UpdatedAt_idx";
+-- Ensure all demographic indices exist.
+-- Uses IF NOT EXISTS to safely handle both environments:
+-- - Develop: Indices already exist from previous migrations, will skip
+-- - Master: May need to create indices if previous migrations timed out
 
--- Drop existing non-concurrent indexes from 20250922154402_more_demographic_indices
-DROP INDEX IF EXISTS "Voter_Precinct_idx";
-DROP INDEX IF EXISTS "Voter_Age_Int_idx";
-DROP INDEX IF EXISTS "Voter_VoterTelephones_CellPhoneFormatted_idx";
-DROP INDEX IF EXISTS "Voter_VoterTelephones_LandlineFormatted_idx";
-DROP INDEX IF EXISTS "Voter_EthnicGroups_EthnicGroup1Desc_idx";
-
--- Drop existing non-concurrent index from 20250923193257_income_int
-DROP INDEX IF EXISTS "Voter_Estimated_Income_Amount_Int_idx";
-
--- Recreate all indexes concurrently (non-blocking)
--- From 20250917185213_demographic_indexes
-CREATE INDEX CONCURRENTLY "Voter_Business_Owner_idx" ON "Voter"("Business_Owner");
-CREATE INDEX CONCURRENTLY "Voter_Education_Of_Person_idx" ON "Voter"("Education_Of_Person");
-CREATE INDEX CONCURRENTLY "Voter_Estimated_Income_Amount_idx" ON "Voter"("Estimated_Income_Amount");
-CREATE INDEX CONCURRENTLY "Voter_Homeowner_Probability_Model_idx" ON "Voter"("Homeowner_Probability_Model");
-CREATE INDEX CONCURRENTLY "Voter_Language_Code_idx" ON "Voter"("Language_Code");
-CREATE INDEX CONCURRENTLY "Voter_Marital_Status_idx" ON "Voter"("Marital_Status");
-CREATE INDEX CONCURRENTLY "Voter_Presence_Of_Children_idx" ON "Voter"("Presence_Of_Children");
-CREATE INDEX CONCURRENTLY "Voter_Registered_Voter_idx" ON "Voter"("Registered_Voter");
-CREATE INDEX CONCURRENTLY "Voter_Veteran_Status_idx" ON "Voter"("Veteran_Status");
-CREATE INDEX CONCURRENTLY "Voter_Voter_Status_idx" ON "Voter"("Voter_Status");
-CREATE INDEX CONCURRENTLY "Voter_Voter_Status_UpdatedAt_idx" ON "Voter"("Voter_Status_UpdatedAt");
-
--- From 20250922154402_more_demographic_indices
-CREATE INDEX CONCURRENTLY "Voter_Precinct_idx" ON "Voter"("Precinct");
-CREATE INDEX CONCURRENTLY "Voter_Age_Int_idx" ON "Voter"("Age_Int");
-CREATE INDEX CONCURRENTLY "Voter_VoterTelephones_CellPhoneFormatted_idx" ON "Voter"("VoterTelephones_CellPhoneFormatted");
-CREATE INDEX CONCURRENTLY "Voter_VoterTelephones_LandlineFormatted_idx" ON "Voter"("VoterTelephones_LandlineFormatted");
-CREATE INDEX CONCURRENTLY "Voter_EthnicGroups_EthnicGroup1Desc_idx" ON "Voter"("EthnicGroups_EthnicGroup1Desc");
-
--- From 20250923193257_income_int
-CREATE INDEX CONCURRENTLY "Voter_Estimated_Income_Amount_Int_idx" ON "Voter"("Estimated_Income_Amount_Int");
+CREATE INDEX IF NOT EXISTS "Voter_Business_Owner_idx" ON "Voter"("Business_Owner");
+CREATE INDEX IF NOT EXISTS "Voter_Education_Of_Person_idx" ON "Voter"("Education_Of_Person");
+CREATE INDEX IF NOT EXISTS "Voter_Estimated_Income_Amount_idx" ON "Voter"("Estimated_Income_Amount");
+CREATE INDEX IF NOT EXISTS "Voter_Homeowner_Probability_Model_idx" ON "Voter"("Homeowner_Probability_Model");
+CREATE INDEX IF NOT EXISTS "Voter_Language_Code_idx" ON "Voter"("Language_Code");
+CREATE INDEX IF NOT EXISTS "Voter_Marital_Status_idx" ON "Voter"("Marital_Status");
+CREATE INDEX IF NOT EXISTS "Voter_Presence_Of_Children_idx" ON "Voter"("Presence_Of_Children");
+CREATE INDEX IF NOT EXISTS "Voter_Registered_Voter_idx" ON "Voter"("Registered_Voter");
+CREATE INDEX IF NOT EXISTS "Voter_Veteran_Status_idx" ON "Voter"("Veteran_Status");
+CREATE INDEX IF NOT EXISTS "Voter_Voter_Status_idx" ON "Voter"("Voter_Status");
+CREATE INDEX IF NOT EXISTS "Voter_Voter_Status_UpdatedAt_idx" ON "Voter"("Voter_Status_UpdatedAt");
+CREATE INDEX IF NOT EXISTS "Voter_Precinct_idx" ON "Voter"("Precinct");
+CREATE INDEX IF NOT EXISTS "Voter_Age_Int_idx" ON "Voter"("Age_Int");
+CREATE INDEX IF NOT EXISTS "Voter_VoterTelephones_CellPhoneFormatted_idx" ON "Voter"("VoterTelephones_CellPhoneFormatted");
+CREATE INDEX IF NOT EXISTS "Voter_VoterTelephones_LandlineFormatted_idx" ON "Voter"("VoterTelephones_LandlineFormatted");
+CREATE INDEX IF NOT EXISTS "Voter_EthnicGroups_EthnicGroup1Desc_idx" ON "Voter"("EthnicGroups_EthnicGroup1Desc");
+CREATE INDEX IF NOT EXISTS "Voter_Estimated_Income_Amount_Int_idx" ON "Voter"("Estimated_Income_Amount_Int");

--- a/prisma/migrations/20250930000000_recreate_demographic_indices_concurrently/migration.sql
+++ b/prisma/migrations/20250930000000_recreate_demographic_indices_concurrently/migration.sql
@@ -1,22 +1,10 @@
--- Ensure all demographic indices exist.
--- Uses IF NOT EXISTS to safely handle both environments:
--- - Develop: Indices already exist from previous migrations, will skip
--- - Master: May need to create indices if previous migrations timed out
-
-CREATE INDEX IF NOT EXISTS "Voter_Business_Owner_idx" ON "Voter"("Business_Owner");
-CREATE INDEX IF NOT EXISTS "Voter_Education_Of_Person_idx" ON "Voter"("Education_Of_Person");
-CREATE INDEX IF NOT EXISTS "Voter_Estimated_Income_Amount_idx" ON "Voter"("Estimated_Income_Amount");
-CREATE INDEX IF NOT EXISTS "Voter_Homeowner_Probability_Model_idx" ON "Voter"("Homeowner_Probability_Model");
-CREATE INDEX IF NOT EXISTS "Voter_Language_Code_idx" ON "Voter"("Language_Code");
-CREATE INDEX IF NOT EXISTS "Voter_Marital_Status_idx" ON "Voter"("Marital_Status");
-CREATE INDEX IF NOT EXISTS "Voter_Presence_Of_Children_idx" ON "Voter"("Presence_Of_Children");
-CREATE INDEX IF NOT EXISTS "Voter_Registered_Voter_idx" ON "Voter"("Registered_Voter");
-CREATE INDEX IF NOT EXISTS "Voter_Veteran_Status_idx" ON "Voter"("Veteran_Status");
-CREATE INDEX IF NOT EXISTS "Voter_Voter_Status_idx" ON "Voter"("Voter_Status");
-CREATE INDEX IF NOT EXISTS "Voter_Voter_Status_UpdatedAt_idx" ON "Voter"("Voter_Status_UpdatedAt");
-CREATE INDEX IF NOT EXISTS "Voter_Precinct_idx" ON "Voter"("Precinct");
-CREATE INDEX IF NOT EXISTS "Voter_Age_Int_idx" ON "Voter"("Age_Int");
-CREATE INDEX IF NOT EXISTS "Voter_VoterTelephones_CellPhoneFormatted_idx" ON "Voter"("VoterTelephones_CellPhoneFormatted");
-CREATE INDEX IF NOT EXISTS "Voter_VoterTelephones_LandlineFormatted_idx" ON "Voter"("VoterTelephones_LandlineFormatted");
-CREATE INDEX IF NOT EXISTS "Voter_EthnicGroups_EthnicGroup1Desc_idx" ON "Voter"("EthnicGroups_EthnicGroup1Desc");
-CREATE INDEX IF NOT EXISTS "Voter_Estimated_Income_Amount_Int_idx" ON "Voter"("Estimated_Income_Amount_Int");
+-- Phase 1: Deploy increased grace period (900s) to handle long-running migrations.
+-- This migration is intentionally minimal to succeed with the current 300s grace period.
+-- 
+-- Next steps after this deploys:
+-- 1. The 900s grace period will be active in both environments
+-- 2. A follow-up migration can then safely recreate indices with CONCURRENTLY
+--
+-- Note: Demographic indices from migrations 20250917185213, 20250922154402, and 20250923193257
+-- exist in develop (small DB) and may be incomplete in master (large DB, timeouts).
+-- They will be properly recreated with CONCURRENTLY in a follow-up migration.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switches the migration to idempotently create voter demographic indexes using IF NOT EXISTS, removing drops and CONCURRENTLY recreations.
> 
> - **Database migration** (`prisma/migrations/20250930000000_recreate_demographic_indices_concurrently/migration.sql`):
>   - Replace drop-and-recreate (CONCURRENTLY) strategy with idempotent `CREATE INDEX IF NOT EXISTS` statements.
>   - Ensures presence of multiple `Voter` demographic indices (e.g., `Business_Owner`, `Education_Of_Person`, `Estimated_Income_Amount`, `Precinct`, `Age_Int`, telephone formats, `EthnicGroups_EthnicGroup1Desc`, and `Estimated_Income_Amount_Int`) without dropping existing ones.
>   - Adds comments clarifying behavior across environments.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1b054ad9535bc45df7dd23b86bcd1447e732633c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->