### PR TITLE
chore: one more migration

### DIFF
--- a/prisma/migrations/20250930100000_add_missing_demographic_indices/migration.sql
+++ b/prisma/migrations/20250930100000_add_missing_demographic_indices/migration.sql
@@ -1,0 +1,29 @@
+-- Create missing demographic indices with CONCURRENTLY for non-blocking operation.
+-- These indices were skipped during initial deployment due to timeout issues.
+-- CONCURRENTLY allows the database to remain fully operational during index creation.
+--
+-- Expected duration on large production DB: 15-20 minutes
+-- Develop (small DB) will complete in seconds
+
+-- From 20250917185213_demographic_indexes
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "Voter_Business_Owner_idx" ON "Voter"("Business_Owner");
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "Voter_Education_Of_Person_idx" ON "Voter"("Education_Of_Person");
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "Voter_Estimated_Income_Amount_idx" ON "Voter"("Estimated_Income_Amount");
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "Voter_Homeowner_Probability_Model_idx" ON "Voter"("Homeowner_Probability_Model");
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "Voter_Language_Code_idx" ON "Voter"("Language_Code");
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "Voter_Marital_Status_idx" ON "Voter"("Marital_Status");
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "Voter_Presence_Of_Children_idx" ON "Voter"("Presence_Of_Children");
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "Voter_Registered_Voter_idx" ON "Voter"("Registered_Voter");
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "Voter_Veteran_Status_idx" ON "Voter"("Veteran_Status");
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "Voter_Voter_Status_idx" ON "Voter"("Voter_Status");
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "Voter_Voter_Status_UpdatedAt_idx" ON "Voter"("Voter_Status_UpdatedAt");
+
+-- From 20250922154402_more_demographic_indices
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "Voter_Precinct_idx" ON "Voter"("Precinct");
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "Voter_Age_Int_idx" ON "Voter"("Age_Int");
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "Voter_VoterTelephones_CellPhoneFormatted_idx" ON "Voter"("VoterTelephones_CellPhoneFormatted");
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "Voter_VoterTelephones_LandlineFormatted_idx" ON "Voter"("VoterTelephones_LandlineFormatted");
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "Voter_EthnicGroups_EthnicGroup1Desc_idx" ON "Voter"("EthnicGroups_EthnicGroup1Desc");
+
+-- From 20250923193257_income_int
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "Voter_Estimated_Income_Amount_Int_idx" ON "Voter"("Estimated_Income_Amount_Int");


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a migration that creates non-blocking concurrent indexes on multiple `Voter` demographic and related columns.
> 
> - **Database Migration**:
>   - **Add concurrent indexes** in `prisma/migrations/20250930100000_add_missing_demographic_indices/migration.sql` on `Voter` columns:
>     - Demographics: `Business_Owner`, `Education_Of_Person`, `Estimated_Income_Amount`, `Homeowner_Probability_Model`, `Language_Code`, `Marital_Status`, `Presence_Of_Children`, `Veteran_Status`, `Voter_Status`, `Voter_Status_UpdatedAt`, `EthnicGroups_EthnicGroup1Desc`
>     - Geography/Age: `Precinct`, `Age_Int`
>     - Contact: `VoterTelephones_CellPhoneFormatted`, `VoterTelephones_LandlineFormatted`
>     - Income (int): `Estimated_Income_Amount_Int`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 14bc3553a2acd09f5ec80dd294ef374b8ca5ed42. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->