### PR TITLE
ENG-3897 - Search for a person

### DIFF
--- a/api-examples.http
+++ b/api-examples.http
@@ -1,14 +1,14 @@
 ### List people from a district
-GET http://localhost:3002/v1/people?state=WY&districtType=Unified_School_District&districtName=LINCOLN%20CNTY%20SD%202%20(EST.)
+GET http://localhost:3002/v1/people/list?state=WY&districtType=Unified_School_District&districtName=LINCOLN%20CNTY%20SD%202%20(EST.)
 
 ### List people with language and voter status filters
-GET http://localhost:3002/v1/people?state=WY&districtType=Unified_School_District&districtName=LINCOLN%20CNTY%20SD%202%20(EST.)&resultsPerPage=50&page=1&filter[languageCode][in][]=EN&filter[languageCode][in][]=ES&filter[voterStatus][eq]=Active
+GET http://localhost:3002/v1/people/list?state=WY&districtType=Unified_School_District&districtName=LINCOLN%20CNTY%20SD%202%20(EST.)&resultsPerPage=50&page=1&filter[languageCode][in][]=EN&filter[languageCode][in][]=ES&filter[voterStatus][eq]=Active
 
 ### List people where educationOfPerson is non-null
-GET http://localhost:3002/v1/people?state=WY&districtType=Unified_School_District&districtName=LINCOLN%20CNTY%20SD%202%20(EST.)&filter[educationOfPerson][is]=not_null
+GET http://localhost:3002/v1/people/list?state=WY&districtType=Unified_School_District&districtName=LINCOLN%20CNTY%20SD%202%20(EST.)&filter[educationOfPerson][is]=not_null
 
 ### List people with registeredVoter true or false (boolean IN)
-GET http://localhost:3002/v1/people?state=WY&districtType=Unified_School_District&districtName=LINCOLN%20CNTY%20SD%202%20(EST.)&filter[registeredVoter][in][]=true&filter[registeredVoter][in][]=false
+GET http://localhost:3002/v1/people/list?state=WY&districtType=Unified_School_District&districtName=LINCOLN%20CNTY%20SD%202%20(EST.)&filter[registeredVoter][in][]=true&filter[registeredVoter][in][]=false
 
 ### Download CSV with veteranStatus IN and presenceOfChildren is null
 GET http://localhost:3002/v1/people/download?state=WY&districtType=Unified_School_District&districtName=LINCOLN%20CNTY%20SD%202%20(EST.)&filter[veteranStatus][in][]=Yes&filter[veteranStatus][in][]=No&filter[presenceOfChildren][is]=null
@@ -26,6 +26,12 @@ GET http://localhost:3002/v1/people/stats?state=WY&districtType=Unified_School_D
 ### Stats: with demographic filter (registeredVoter true, veteranStatus in Yes/No)
 GET http://localhost:3002/v1/people/stats?state=WY&districtType=Unified_School_District&districtName=LINCOLN%20CNTY%20SD%202%20(EST.)&filter[registeredVoter][eq]=true&filter[veteranStatus][in][]=Yes&filter[veteranStatus][in][]=No
 
-### Get a specific person by ID
-GET http://localhost:3002/v1/people/12345678-1234-1234-1234-123456789abc
+### Search voters by phone
+GET http://localhost:3002/v1/people/search?phone=213-555-0182&state=CA
+
+### Search voters by name
+GET http://localhost:3002/v1/people/search?name=Ada%20Lovelace&state=CA
+
+### Search voters by first and last name with district
+GET http://localhost:3002/v1/people/search?firstName=Ada&lastName=Lovelace&state=CA&districtType=US_Congressional_District&districtName=CA-12&page=1&resultsPerPage=25
 

--- a/api-examples.http
+++ b/api-examples.http
@@ -27,11 +27,11 @@ GET http://localhost:3002/v1/people/stats?state=WY&districtType=Unified_School_D
 GET http://localhost:3002/v1/people/stats?state=WY&districtType=Unified_School_District&districtName=LINCOLN%20CNTY%20SD%202%20(EST.)&filter[registeredVoter][eq]=true&filter[veteranStatus][in][]=Yes&filter[veteranStatus][in][]=No
 
 ### Search voters by phone
-GET http://localhost:3002/v1/people/search?phone=213-555-0182&state=CA
+GET http://localhost:3002/v1/people/search?phone=307-248-0741&state=WY
 
 ### Search voters by name
-GET http://localhost:3002/v1/people/search?name=Ada%20Lovelace&state=CA
+GET http://localhost:3002/v1/people/search?name=David%20Hokanson&state=WY
 
 ### Search voters by first and last name with district
-GET http://localhost:3002/v1/people/search?firstName=Ada&lastName=Lovelace&state=CA&districtType=US_Congressional_District&districtName=CA-12&page=1&resultsPerPage=25
+GET http://localhost:3002/v1/people/search?firstName=David&lastName=Hokanson&state=WY&districtType=Unified_School_District&districtName=LINCOLN%20CNTY%20SD%202%20(EST.)&page=1&resultsPerPage=25
 

--- a/api-examples.http
+++ b/api-examples.http
@@ -1,14 +1,14 @@
 ### List people from a district
-GET http://localhost:3002/v1/people/list?state=WY&districtType=Unified_School_District&districtName=LINCOLN%20CNTY%20SD%202%20(EST.)
+GET http://localhost:3002/v1/people?state=WY&districtType=Unified_School_District&districtName=LINCOLN%20CNTY%20SD%202%20(EST.)
 
 ### List people with language and voter status filters
-GET http://localhost:3002/v1/people/list?state=WY&districtType=Unified_School_District&districtName=LINCOLN%20CNTY%20SD%202%20(EST.)&resultsPerPage=50&page=1&filter[languageCode][in][]=EN&filter[languageCode][in][]=ES&filter[voterStatus][eq]=Active
+GET http://localhost:3002/v1/people?state=WY&districtType=Unified_School_District&districtName=LINCOLN%20CNTY%20SD%202%20(EST.)&resultsPerPage=50&page=1&filter[languageCode][in][]=EN&filter[languageCode][in][]=ES&filter[voterStatus][eq]=Active
 
 ### List people where educationOfPerson is non-null
-GET http://localhost:3002/v1/people/list?state=WY&districtType=Unified_School_District&districtName=LINCOLN%20CNTY%20SD%202%20(EST.)&filter[educationOfPerson][is]=not_null
+GET http://localhost:3002/v1/people?state=WY&districtType=Unified_School_District&districtName=LINCOLN%20CNTY%20SD%202%20(EST.)&filter[educationOfPerson][is]=not_null
 
 ### List people with registeredVoter true or false (boolean IN)
-GET http://localhost:3002/v1/people/list?state=WY&districtType=Unified_School_District&districtName=LINCOLN%20CNTY%20SD%202%20(EST.)&filter[registeredVoter][in][]=true&filter[registeredVoter][in][]=false
+GET http://localhost:3002/v1/people?state=WY&districtType=Unified_School_District&districtName=LINCOLN%20CNTY%20SD%202%20(EST.)&filter[registeredVoter][in][]=true&filter[registeredVoter][in][]=false
 
 ### Download CSV with veteranStatus IN and presenceOfChildren is null
 GET http://localhost:3002/v1/people/download?state=WY&districtType=Unified_School_District&districtName=LINCOLN%20CNTY%20SD%202%20(EST.)&filter[veteranStatus][in][]=Yes&filter[veteranStatus][in][]=No&filter[presenceOfChildren][is]=null

--- a/src/people/people.controller.ts
+++ b/src/people/people.controller.ts
@@ -7,7 +7,12 @@ import {
   Query,
   Res,
 } from '@nestjs/common'
-import { DownloadPeopleDTO, ListPeopleDTO, StatsDTO } from './people.schema'
+import {
+  DownloadPeopleDTO,
+  ListPeopleDTO,
+  SearchPeopleDTO,
+  StatsDTO,
+} from './people.schema'
 import { PeopleService } from './services/people.service'
 import { StatsService } from './services/stats.service'
 import { FastifyReply } from 'fastify'
@@ -37,6 +42,11 @@ export class PeopleController {
   @Get('stats')
   getStats(@Query() dto: StatsDTO) {
     return this.statsService.getStats(dto)
+  }
+
+  @Get('search')
+  search(@Query() dto: SearchPeopleDTO) {
+    return this.peopleService.searchVoters(dto)
   }
 
   @Get(':id')

--- a/src/people/people.schema.ts
+++ b/src/people/people.schema.ts
@@ -150,6 +150,37 @@ export const downloadPeopleSchema = z.object({
 
 export class DownloadPeopleDTO extends createZodDto(downloadPeopleSchema) {}
 
+export const searchPeopleSchema = z
+  .object({
+    state: stateSchema.optional(),
+    districtType: z.string().optional(),
+    districtName: z.string().optional(),
+    phone: z.string().optional(),
+    name: z.string().optional(),
+    firstName: z.string().optional(),
+    lastName: z.string().optional(),
+    resultsPerPage: z.coerce
+      .number()
+      .int()
+      .min(1)
+      .max(50)
+      .optional()
+      .default(25),
+    page: z.coerce.number().int().min(1).optional().default(1),
+  })
+  .refine(
+    (v) => !!(v.phone || v.name || v.firstName || v.lastName),
+    'Provide phone or name to search',
+  )
+  .refine(
+    (v) =>
+      (v.districtType && v.districtName) ||
+      (!v.districtType && !v.districtName),
+    'districtType and districtName must be provided together',
+  )
+
+export class SearchPeopleDTO extends createZodDto(searchPeopleSchema) {}
+
 // ---- Stats DTO ----
 const allowedCategoryDefaults = [
   'age',

--- a/src/people/services/people.service.ts
+++ b/src/people/services/people.service.ts
@@ -100,17 +100,19 @@ export class PeopleService extends createPrismaBase(MODELS.Voter) {
         { VoterTelephones_LandlineFormatted: formatted },
       ]
     } else if (hasNameTokens) {
-      const fn = firstName ?? tokens[0]
-      const ln =
-        lastName ?? (tokens.length > 1 ? tokens[tokens.length - 1] : tokens[0])
+      const explicitFirst = Boolean(firstName)
+      const explicitLast = Boolean(lastName)
+      const twoTokens = tokens.length > 1
 
-      if (fn && ln) {
+      if ((explicitFirst && explicitLast) || twoTokens) {
+        const fn = firstName ?? tokens[0]
+        const ln = lastName ?? tokens[tokens.length - 1]
         where.AND = [
           { FirstName: { equals: fn, mode: Prisma.QueryMode.default } },
           { LastName: { equals: ln, mode: Prisma.QueryMode.default } },
         ]
       } else {
-        const single = fn || ln
+        const single = firstName ?? lastName ?? tokens[0]
         where.OR = [
           {
             FirstName: {

--- a/src/people/services/people.service.ts
+++ b/src/people/services/people.service.ts
@@ -106,14 +106,24 @@ export class PeopleService extends createPrismaBase(MODELS.Voter) {
 
       if (fn && ln) {
         where.AND = [
-          { FirstName: { startsWith: fn, mode: 'insensitive' } },
-          { LastName: { startsWith: ln, mode: 'insensitive' } },
+          { FirstName: { equals: fn, mode: Prisma.QueryMode.default } },
+          { LastName: { equals: ln, mode: Prisma.QueryMode.default } },
         ]
       } else {
         const single = fn || ln
         where.OR = [
-          { FirstName: { startsWith: single as string, mode: 'insensitive' } },
-          { LastName: { startsWith: single as string, mode: 'insensitive' } },
+          {
+            FirstName: {
+              equals: single as string,
+              mode: Prisma.QueryMode.default,
+            },
+          },
+          {
+            LastName: {
+              equals: single as string,
+              mode: Prisma.QueryMode.default,
+            },
+          },
         ]
       }
     }


### PR DESCRIPTION
https://goodpartyorg.postman.co/workspace/people-api~a462385a-9d9d-4b73-a25e-b0832ecd8106/request/38601784-b4d2b72c-0e5b-4b56-9fd9-13c1a0948729?action=share&source=copy-link&creator=38601784&active-environment=892902c7-45eb-4e6b-ae1e-da0c43de965f

https://goodpartyorg.postman.co/workspace/people-api~a462385a-9d9d-4b73-a25e-b0832ecd8106/request/38601784-5dd30768-a3b1-4018-a5cf-e0986410afbf?action=share&source=copy-link&creator=38601784&active-environment=892902c7-45eb-4e6b-ae1e-da0c43de965f

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add `/v1/people/search` supporting phone/name queries with pagination and update API examples (including using `/v1/people/list`).
> 
> - **API**:
>   - Add `GET /v1/people/search` for voter lookup by `phone`, `name`, or `firstName`/`lastName`, with optional `state` and district filters, plus pagination.
> - **Backend**:
>   - `PeopleController`: new `search(@Query() dto: SearchPeopleDTO)` route.
>   - `PeopleService`: implement `searchVoters` with phone normalization/formatting, name token handling, dynamic district filter, ordered results, and paginated response; select key voter fields.
> - **Schema**:
>   - Add `SearchPeopleDTO`/`searchPeopleSchema` with validations (requires phone or name; `districtType`/`districtName` pairing; page/size limits).
> - **Docs/Examples**:
>   - Update `api-examples.http`: use `GET /v1/people/list` for listing; add search-by-phone/name examples; remove get-by-id example.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f4620afd5e4151eebaeb65caba3bf25a49977973. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->