### PR TITLE
Prod release

### DIFF
--- a/api-examples.http
+++ b/api-examples.http
@@ -26,6 +26,12 @@ GET http://localhost:3002/v1/people/stats?state=WY&districtType=Unified_School_D
 ### Stats: with demographic filter (registeredVoter true, veteranStatus in Yes/No)
 GET http://localhost:3002/v1/people/stats?state=WY&districtType=Unified_School_District&districtName=LINCOLN%20CNTY%20SD%202%20(EST.)&filter[registeredVoter][eq]=true&filter[veteranStatus][in][]=Yes&filter[veteranStatus][in][]=No
 
-### Get a specific person by ID
-GET http://localhost:3002/v1/people/12345678-1234-1234-1234-123456789abc
+### Search voters by phone
+GET http://localhost:3002/v1/people/search?phone=307-248-0741&state=WY
+
+### Search voters by name
+GET http://localhost:3002/v1/people/search?name=David%20Hokanson&state=WY
+
+### Search voters by first and last name with district
+GET http://localhost:3002/v1/people/search?firstName=David&lastName=Hokanson&state=WY&districtType=Unified_School_District&districtName=LINCOLN%20CNTY%20SD%202%20(EST.)&page=1&resultsPerPage=25
 

--- a/src/people/people.controller.ts
+++ b/src/people/people.controller.ts
@@ -7,7 +7,12 @@ import {
   Query,
   Res,
 } from '@nestjs/common'
-import { DownloadPeopleDTO, ListPeopleDTO, StatsDTO } from './people.schema'
+import {
+  DownloadPeopleDTO,
+  ListPeopleDTO,
+  SearchPeopleDTO,
+  StatsDTO,
+} from './people.schema'
 import { PeopleService } from './services/people.service'
 import { StatsService } from './services/stats.service'
 import { FastifyReply } from 'fastify'
@@ -37,6 +42,11 @@ export class PeopleController {
   @Get('stats')
   getStats(@Query() dto: StatsDTO) {
     return this.statsService.getStats(dto)
+  }
+
+  @Get('search')
+  search(@Query() dto: SearchPeopleDTO) {
+    return this.peopleService.searchVoters(dto)
   }
 
   @Get(':id')

--- a/src/people/people.schema.ts
+++ b/src/people/people.schema.ts
@@ -150,6 +150,37 @@ export const downloadPeopleSchema = z.object({
 
 export class DownloadPeopleDTO extends createZodDto(downloadPeopleSchema) {}
 
+export const searchPeopleSchema = z
+  .object({
+    state: stateSchema.optional(),
+    districtType: z.string().optional(),
+    districtName: z.string().optional(),
+    phone: z.string().optional(),
+    name: z.string().optional(),
+    firstName: z.string().optional(),
+    lastName: z.string().optional(),
+    resultsPerPage: z.coerce
+      .number()
+      .int()
+      .min(1)
+      .max(50)
+      .optional()
+      .default(25),
+    page: z.coerce.number().int().min(1).optional().default(1),
+  })
+  .refine(
+    (v) => !!(v.phone || v.name || v.firstName || v.lastName),
+    'Provide phone or name to search',
+  )
+  .refine(
+    (v) =>
+      (v.districtType && v.districtName) ||
+      (!v.districtType && !v.districtName),
+    'districtType and districtName must be provided together',
+  )
+
+export class SearchPeopleDTO extends createZodDto(searchPeopleSchema) {}
+
 // ---- Stats DTO ----
 const allowedCategoryDefaults = [
   'age',

--- a/src/people/services/people.service.ts
+++ b/src/people/services/people.service.ts
@@ -1,5 +1,9 @@
 import { Prisma } from '@prisma/client'
-import { DownloadPeopleDTO, ListPeopleDTO } from '../people.schema'
+import {
+  DownloadPeopleDTO,
+  ListPeopleDTO,
+  SearchPeopleDTO,
+} from '../people.schema'
 import { createPrismaBase, MODELS } from 'src/prisma/util/prisma.util'
 import {
   DEMOGRAPHIC_FILTER_FIELDS,
@@ -45,6 +49,138 @@ export class PeopleService extends createPrismaBase(MODELS.Voter) {
     return isEvenYear
       ? 'VotingPerformanceEvenYearGeneral'
       : 'VotingPerformanceMinorElection'
+  }
+
+  private normalizePhone(input: string): string | null {
+    const digits = (input || '').replace(/\D/g, '')
+    if (digits.length === 11 && digits.startsWith('1')) return digits.slice(1)
+    if (digits.length === 10) return digits
+    return null
+  }
+
+  private formatStoredPhoneFromDigits(digits: string): string {
+    const area = digits.slice(0, 3)
+    const prefix = digits.slice(3, 6)
+    const line = digits.slice(6)
+    return `(${area}) ${prefix}-${line}`
+  }
+
+  async searchVoters(dto: SearchPeopleDTO) {
+    const {
+      state,
+      districtType,
+      districtName,
+      phone,
+      name,
+      firstName,
+      lastName,
+      resultsPerPage,
+      page,
+    } = dto
+
+    this.validateDistrictType(districtType)
+
+    const where: Prisma.VoterWhereInput = {}
+
+    if (state) where.State = state
+
+    const tokens = (name || '').trim().split(/\s+/).filter(Boolean)
+    const hasNameTokens = tokens.length > 0 || firstName || lastName
+
+    if (phone) {
+      const normalized = this.normalizePhone(phone)
+      if (!normalized) {
+        throw new BadRequestException(
+          'Invalid phone number; expected 10 digits',
+        )
+      }
+      const formatted = this.formatStoredPhoneFromDigits(normalized)
+      where.OR = [
+        { VoterTelephones_CellPhoneFormatted: formatted },
+        { VoterTelephones_LandlineFormatted: formatted },
+      ]
+    } else if (hasNameTokens) {
+      const explicitFirst = Boolean(firstName)
+      const explicitLast = Boolean(lastName)
+      const twoTokens = tokens.length > 1
+
+      if ((explicitFirst && explicitLast) || twoTokens) {
+        const fn = firstName ?? tokens[0]
+        const ln = lastName ?? tokens[tokens.length - 1]
+        where.AND = [
+          { FirstName: { equals: fn, mode: Prisma.QueryMode.default } },
+          { LastName: { equals: ln, mode: Prisma.QueryMode.default } },
+        ]
+      } else {
+        const single = firstName ?? lastName ?? tokens[0]
+        where.OR = [
+          {
+            FirstName: {
+              equals: single as string,
+              mode: Prisma.QueryMode.default,
+            },
+          },
+          {
+            LastName: {
+              equals: single as string,
+              mode: Prisma.QueryMode.default,
+            },
+          },
+        ]
+      }
+    }
+
+    if (districtType && districtName) {
+      ;(where as Record<string, unknown>)[districtType as string] = {
+        equals: districtName,
+      }
+    }
+
+    const take = resultsPerPage
+    const skip = (page - 1) * resultsPerPage
+
+    const select: Prisma.VoterSelect = {
+      id: true,
+      LALVOTERID: true,
+      State: true,
+      FirstName: true,
+      MiddleName: true,
+      LastName: true,
+      NameSuffix: true,
+      VoterTelephones_CellPhoneFormatted: true,
+      VoterTelephones_LandlineFormatted: true,
+      Residence_Addresses_City: true,
+      Residence_Addresses_State: true,
+      Residence_Addresses_Zip: true,
+      Registered_Voter: true,
+      Parties_Description: true,
+    }
+
+    const [totalResults, results] = await Promise.all([
+      this.model.count({ where }),
+      this.model.findMany({
+        where,
+        take,
+        skip,
+        select,
+        orderBy: [{ LastName: 'asc' }, { FirstName: 'asc' }],
+      }),
+    ])
+
+    const totalPages = Math.max(1, Math.ceil(totalResults / resultsPerPage))
+    const currentPage = Math.min(Math.max(1, page), totalPages)
+
+    return {
+      pagination: {
+        totalResults,
+        currentPage,
+        pageSize: resultsPerPage,
+        totalPages,
+        hasNextPage: currentPage < totalPages,
+        hasPreviousPage: currentPage > 1,
+      },
+      results,
+    }
   }
 
   async findPeople(dto: ListPeopleDTO) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces `/v1/people/search` for phone/name queries, adds missing voter demographic indexes, and updates income stats to check for the int column before numeric bucketing.
> 
> - **API**:
>   - Add `GET /v1/people/search` in `people.controller.ts` using `SearchPeopleDTO` (query by `phone`, `name`, or `firstName`/`lastName`, optional `state`/district, paginated).
>   - Update `api-examples.http` with search examples; remove single person-by-ID example.
> - **Backend**:
>   - Implement `searchVoters` in `people.service.ts` (phone normalization/formatting, name token handling, district validation, ordered/paginated results with selected fields).
>   - Add `SearchPeopleDTO` and `searchPeopleSchema` in `people.schema.ts` with validations.
>   - In `stats.service.ts`, guard income bucketing by checking existence of `Estimated_Income_Amount_Int`; fallback to string buckets when needed.
> - **Database**:
>   - New migration creates missing demographic indexes on `Voter` without `CONCURRENTLY` (standard `CREATE INDEX IF NOT EXISTS`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5382806a9c9f907e4bd34033da63172bbecf19c0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->