### PR TITLE
Add better logging, and prisma specific handling

### DIFF
--- a/src/health/health.service.ts
+++ b/src/health/health.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common'
+import { serializeError } from 'src/shared/logging.util'
 import { PrismaService } from '../prisma/prisma.service'
 
 @Injectable()
@@ -22,10 +23,7 @@ export class HealthService {
       this.logger.debug('Database health check passed')
       return true
     } catch (e: unknown) {
-      this.logger.error(
-        'Health check failed => ',
-        e instanceof Error ? e.message : e,
-      )
+      this.logger.error(`Health check failed => ${serializeError(e)}`)
       return false
     }
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,6 +13,7 @@ import { Logger } from '@nestjs/common'
 import fastifyStatic from '@fastify/static'
 import { join } from 'path'
 import { ZodValidationPipe } from 'nestjs-zod'
+import { AllExceptionsFilter } from './shared/http-exception.filter'
 import qs from 'qs'
 
 const APP_LISTEN_CONFIG = {
@@ -49,7 +50,6 @@ const bootstrap = async () => {
   app.useGlobalPipes(new ZodValidationPipe())
 
   const httpAdapterHost = app.get(HttpAdapterHost)
-  const { AllExceptionsFilter } = await import('./shared/http-exception.filter')
   app.useGlobalFilters(new AllExceptionsFilter(httpAdapterHost))
 
   const swaggerConfig = new DocumentBuilder()

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import '../../module-alias'
 import './configrc'
-import { NestFactory } from '@nestjs/core'
+import { HttpAdapterHost, NestFactory } from '@nestjs/core'
 import {
   FastifyAdapter,
   NestFastifyApplication,
@@ -47,6 +47,10 @@ const bootstrap = async () => {
   )
   app.setGlobalPrefix('v1')
   app.useGlobalPipes(new ZodValidationPipe())
+
+  const httpAdapterHost = app.get(HttpAdapterHost)
+  const { AllExceptionsFilter } = await import('./shared/http-exception.filter')
+  app.useGlobalFilters(new AllExceptionsFilter(httpAdapterHost))
 
   const swaggerConfig = new DocumentBuilder()
     .setTitle('API Documentation')

--- a/src/shared/http-exception.filter.ts
+++ b/src/shared/http-exception.filter.ts
@@ -1,0 +1,17 @@
+import { ArgumentsHost, Catch, Logger } from '@nestjs/common'
+import { BaseExceptionFilter, HttpAdapterHost } from '@nestjs/core'
+import { serializeError } from './logging.util'
+
+@Catch()
+export class AllExceptionsFilter extends BaseExceptionFilter {
+  private readonly logger = new Logger('Exceptions')
+
+  constructor(httpAdapterHost: HttpAdapterHost) {
+    super(httpAdapterHost.httpAdapter)
+  }
+
+  catch(exception: unknown, host: ArgumentsHost): void {
+    this.logger.error(serializeError(exception))
+    super.catch(exception, host)
+  }
+}

--- a/src/shared/logging.util.ts
+++ b/src/shared/logging.util.ts
@@ -1,0 +1,53 @@
+import { Prisma } from '@prisma/client'
+
+function isPrismaKnownRequestError(
+  error: unknown,
+): error is Prisma.PrismaClientKnownRequestError {
+  return error instanceof Prisma.PrismaClientKnownRequestError
+}
+
+function buildLogObject(error: unknown): Record<string, unknown> {
+  if (error instanceof Error) {
+    const base: Record<string, unknown> = {
+      name: error.name,
+      message: error.message,
+      stack: error.stack,
+    }
+
+    if (isPrismaKnownRequestError(error)) {
+      base.code = error.code
+      base.clientVersion = error.clientVersion
+      base.meta = error.meta
+    }
+
+    const cause = (error as Error & { cause?: unknown }).cause
+    if (cause !== undefined) {
+      base.cause = buildLogObject(cause)
+    }
+
+    return base
+  }
+
+  return { value: error }
+}
+
+function getSafeReplacer() {
+  const seen = new WeakSet<object>()
+  return (_key: string, value: unknown) => {
+    if (typeof value === 'object' && value !== null) {
+      if (seen.has(value as object)) {
+        return '[Circular]'
+      }
+      seen.add(value as object)
+    }
+    return value
+  }
+}
+
+export function serializeError(error: unknown): string {
+  return JSON.stringify(buildLogObject(error), getSafeReplacer())
+}
+
+export function errorToLogObject(error: unknown): Record<string, unknown> {
+  return buildLogObject(error)
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduce a global exception filter and structured error serialization (incl. Prisma details), and update health check logging to use it.
> 
> - **Backend / Logging**:
>   - **Structured Error Serialization**: Add `src/shared/logging.util.ts` with `serializeError` and `errorToLogObject` (handles Prisma known request errors, circular refs).
>   - **Global Exception Handling**: Implement `AllExceptionsFilter` in `src/shared/http-exception.filter.ts` to log serialized errors; register globally in `src/main.ts` using `HttpAdapterHost`.
>   - **Health Check Logging**: Update `src/health/health.service.ts` to log failures via `serializeError`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 94ff31a98df9dc38b160002b01e5908cfa017bf8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->