### PR TITLE
ENG-4442 

### DIFF
--- a/src/people/people.controller.ts
+++ b/src/people/people.controller.ts
@@ -18,6 +18,17 @@ import {
 import { PeopleService } from './services/people.service'
 import { StatsService } from './services/stats.service'
 import { FastifyReply } from 'fastify'
+import type { FastifyRequest } from 'fastify'
+
+type S2SPayload = {
+  allowStatewide?: boolean
+  state?: string
+  iss?: string
+  iat?: number
+  exp?: number
+}
+
+type S2SRequest = FastifyRequest & { s2s?: S2SPayload }
 
 @Controller('people')
 export class PeopleController {
@@ -27,7 +38,7 @@ export class PeopleController {
   ) {}
 
   @Get()
-  listPeople(@Query() filterDto: ListPeopleDTO, @Req() req: any) {
+  listPeople(@Query() filterDto: ListPeopleDTO, @Req() req: S2SRequest) {
     this.enforceDistrictOrClaim(filterDto, req)
     return this.peopleService.findPeople(filterDto)
   }
@@ -35,7 +46,7 @@ export class PeopleController {
   @Get('download')
   async downloadPeople(
     @Query() dto: DownloadPeopleDTO,
-    @Req() req: any,
+    @Req() req: S2SRequest,
     @Res() res: FastifyReply,
   ) {
     this.enforceDistrictOrClaim(dto, req)
@@ -45,7 +56,7 @@ export class PeopleController {
   }
 
   @Get('stats')
-  getStats(@Query() dto: StatsDTO, @Req() req: any) {
+  getStats(@Query() dto: StatsDTO, @Req() req: S2SRequest) {
     this.enforceDistrictOrClaim(dto, req)
     return this.statsService.getStats(dto)
   }
@@ -56,7 +67,7 @@ export class PeopleController {
   }
 
   @Get('search')
-  search(@Query() dto: SearchPeopleDTO, @Req() req: any) {
+  search(@Query() dto: SearchPeopleDTO, @Req() req: S2SRequest) {
     this.enforceDistrictOrClaim(dto, req)
     return this.peopleService.searchVoters(dto)
   }
@@ -77,7 +88,7 @@ export class PeopleController {
 
   private enforceDistrictOrClaim(
     dto: { state?: string; districtType?: string; districtName?: string },
-    req: any,
+    req: S2SRequest,
   ) {
     const { districtType, districtName, state } = dto
     const hasDistrict = Boolean(districtType && districtName)

--- a/src/people/people.controller.ts
+++ b/src/people/people.controller.ts
@@ -85,7 +85,8 @@ export class PeopleController {
 
     const allowStatewide = req?.s2s?.allowStatewide === true
     const claimState = req?.s2s?.state
-    if (allowStatewide && state && claimState === state) return
+    const matches = allowStatewide && state && claimState === state
+    if (matches) return
 
     throw new BadRequestException(
       'districtType and districtName are required unless a valid statewide claim is present for the given state',

--- a/src/people/people.schema.ts
+++ b/src/people/people.schema.ts
@@ -123,15 +123,20 @@ const demographicFilterSchema = z.record(fieldOpsSchema)
 
 export const listPeopleSchema = z.object({
   state: stateSchema,
-  districtType: z.string(),
-  districtName: z.string(),
+  districtType: z.string().optional(),
+  districtName: z.string().optional(),
   electionYear: electionYearSchema,
   filters: filtersSchema,
   full: booleanDefault(true),
   resultsPerPage: z.coerce.number().optional().default(50),
   page: z.coerce.number().optional().default(1),
   filter: demographicFilterSchema.optional().default({}),
-})
+}).refine(
+  (v) =>
+    (v.districtType && v.districtName) ||
+    (!v.districtType && !v.districtName),
+  'districtType and districtName must be provided together',
+)
 
 export class ListPeopleDTO extends createZodDto(listPeopleSchema) {}
 


### PR DESCRIPTION
Add gating for federal and state level offices. Only allows statewide/federal querying through a claim on the S2S token.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds district-or-statewide claim gating to people endpoints, prioritizes S2S Bearer auth over localhost bypass, makes district fields optional-with-pairing, and batches stats calculations to reduce DB load.
> 
> - **Auth (`src/auth/s2s-auth.guard.ts`)**:
>   - Prefer validating `Authorization` Bearer token when present; set `request.s2s` on success.
>   - Localhost bypass only if no header is provided; otherwise validate header.
>   - Explicit `UnauthorizedException` for missing/invalid headers or secret.
> - **People API (`src/people/people.controller.ts`)**:
>   - Enforce district or valid statewide claim via `enforceDistrictOrClaim` for `GET /people`, `/people/download`, `/people/stats`, and `/people/search`.
>   - Statewide allowed only when `req.s2s.allowStatewide === true` and `req.s2s.state` matches request `state`.
> - **Schema (`src/people/people.schema.ts`)**:
>   - `listPeopleSchema`: `districtType`/`districtName` now optional but must be provided together.
> - **Performance (`src/people/services/stats.service.ts`)**:
>   - Limit stats task concurrency by batching `Promise.all` in chunks of 4 to reduce Prisma pool pressure.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 217efbcd2f1d8e35d2b85408a1efd3fe305698bc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->