### PR TITLE
Dependabot initial config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+      time: "18:00"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 2
+    labels:
+      - "dependabot"
+      - "security"
+    cooldown:
+      semver-major-days: 14
+      semver-minor-days: 2
+      semver-patch-days: 2
+    groups:
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"


### PR DESCRIPTION
Initial config for Dependabot.

- Groups minor/patch updates into one PR, majors into another (max 2 PRs - they get updated not additional each week)
- cooldown periods so we're not first to adopt new versions which may break or have vulns (14d for majors, 7d for minor/patch)
- Labels with "dependabot" and "security" (both new labels)
- Runs weekly, 6pm ET

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds only a Dependabot config file; no runtime or application logic changes, with the main impact being automated dependency update PR volume and timing.
> 
> **Overview**
> Adds initial Dependabot configuration for npm dependencies, scheduled to run weekly and capped at 2 open PRs.
> 
> Updates are grouped into **minor/patch** vs **major** PRs, PRs are labeled `dependabot` and `security`, and a cooldown delays new version adoption (14 days for majors, 2 days for minor/patch).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 473df3dc9b18c2d3fc6fda21c27df2917b1fc6c7. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->