### PR TITLE
ENG-6500 Support State Level Querying

### DIFF
--- a/src/district/services/district.service.ts
+++ b/src/district/services/district.service.ts
@@ -19,11 +19,12 @@ export class DistrictService extends createPrismaBase(MODELS.District) {
     if (!district) {
       throw new NotFoundException(`District not found for id=${id}`)
     }
+    const { id: districtId, type, name, state } = district
     return {
-      id: district.id,
-      type: district.type,
-      name: district.name,
-      state: district.state,
+      id: districtId,
+      type,
+      name,
+      state,
     }
   }
 

--- a/src/district/services/district.service.ts
+++ b/src/district/services/district.service.ts
@@ -2,8 +2,31 @@ import { Injectable, NotFoundException } from '@nestjs/common'
 import { $Enums } from '@prisma/client'
 import { createPrismaBase, MODELS } from 'src/prisma/util/prisma.util'
 
+export interface DistrictById {
+  id: string
+  type: string
+  name: string
+  state: string
+}
+
 @Injectable()
 export class DistrictService extends createPrismaBase(MODELS.District) {
+  async findDistrictById(id: string): Promise<DistrictById> {
+    const district = await this.model.findUnique({
+      where: { id },
+      select: { id: true, type: true, name: true, state: true },
+    })
+    if (!district) {
+      throw new NotFoundException(`District not found for id=${id}`)
+    }
+    return {
+      id: district.id,
+      type: district.type,
+      name: district.name,
+      state: district.state,
+    }
+  }
+
   async findDistrictId(typeNameState: {
     state: string
     type: string

--- a/src/people/people.schema.test.ts
+++ b/src/people/people.schema.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest'
+import {
+  downloadPeopleSchema,
+  getPersonQuerySchema,
+  listPeopleSchema,
+  samplePeopleSchema,
+  STATE_DISTRICT_TYPE,
+  StatsDTO,
+} from './people.schema'
+
+const DISTRICT_ID = '0e5bafca-93a9-86a5-2522-f373979720df'
+
+describe('people query schemas', () => {
+  it('accepts districtId-only list query', () => {
+    const parsed = listPeopleSchema.parse({
+      districtId: DISTRICT_ID,
+      filters: {},
+    })
+
+    expect(parsed.districtId).toBe(DISTRICT_ID)
+    expect(parsed.state).toBeUndefined()
+    expect(parsed.districtType).toBeUndefined()
+    expect(parsed.districtName).toBeUndefined()
+  })
+
+  it('accepts state + districtType + districtName list query', () => {
+    const parsed = listPeopleSchema.parse({
+      state: 'wy',
+      districtType: 'City_Ward',
+      districtName: 'CHEYENNE CITY WARD 1',
+      filters: {},
+    })
+
+    expect(parsed.state).toBe('WY')
+    expect(parsed.districtType).toBe('City_Ward')
+    expect(parsed.districtName).toBe('CHEYENNE CITY WARD 1')
+  })
+
+  it('normalizes state-only list query to statewide district', () => {
+    const parsed = listPeopleSchema.parse({
+      state: 'wy',
+      filters: {},
+    })
+
+    expect(parsed.state).toBe('WY')
+    expect(parsed.districtType).toBe(STATE_DISTRICT_TYPE)
+    expect(parsed.districtName).toBe('WY')
+  })
+
+  it('rejects mixed districtId + districtType/name list query', () => {
+    expect(() =>
+      listPeopleSchema.parse({
+        districtId: DISTRICT_ID,
+        districtType: 'City_Ward',
+        districtName: 'CHEYENNE CITY WARD 1',
+        filters: {},
+      }),
+    ).toThrow(
+      'Either districtId only, or state + districtType + districtName, or state only',
+    )
+  })
+
+  it('rejects statewide district with mismatched districtName', () => {
+    expect(() =>
+      listPeopleSchema.parse({
+        state: 'WY',
+        districtType: STATE_DISTRICT_TYPE,
+        districtName: 'CO',
+        filters: {},
+      }),
+    ).toThrow('When districtType is State, districtName must equal state')
+  })
+
+  it('accepts districtId-only stats query', () => {
+    const parsed = StatsDTO.create({ districtId: DISTRICT_ID })
+    expect(parsed.districtId).toBe(DISTRICT_ID)
+    expect(parsed.state).toBeUndefined()
+  })
+
+  it('accepts districtId-only sample query', () => {
+    const parsed = samplePeopleSchema.parse({
+      districtId: DISTRICT_ID,
+      size: 25,
+    })
+    expect(parsed.districtId).toBe(DISTRICT_ID)
+    expect(parsed.size).toBe(25)
+  })
+
+  it('accepts districtId-only download query', () => {
+    const parsed = downloadPeopleSchema.parse({
+      districtId: DISTRICT_ID,
+      filters: {},
+    })
+    expect(parsed.districtId).toBe(DISTRICT_ID)
+    expect(parsed.state).toBeUndefined()
+  })
+
+  it('accepts districtId-only getPerson query', () => {
+    const parsed = getPersonQuerySchema.parse({
+      districtId: DISTRICT_ID,
+    })
+    expect(parsed.districtId).toBe(DISTRICT_ID)
+    expect(parsed.state).toBeUndefined()
+  })
+})

--- a/src/people/people.schema.test.ts
+++ b/src/people/people.schema.test.ts
@@ -36,15 +36,15 @@ describe('people query schemas', () => {
     expect(parsed.districtName).toBe('CHEYENNE CITY WARD 1')
   })
 
-  it('normalizes state-only list query to statewide district', () => {
+  it('accepts state-only list query without district normalization', () => {
     const parsed = listPeopleSchema.parse({
       state: 'wy',
       filters: {},
     })
 
     expect(parsed.state).toBe('WY')
-    expect(parsed.districtType).toBe(STATE_DISTRICT_TYPE)
-    expect(parsed.districtName).toBe('WY')
+    expect(parsed.districtType).toBeUndefined()
+    expect(parsed.districtName).toBeUndefined()
   })
 
   it('rejects mixed districtId + districtType/name list query', () => {
@@ -55,9 +55,7 @@ describe('people query schemas', () => {
         districtName: 'CHEYENNE CITY WARD 1',
         filters: {},
       }),
-    ).toThrow(
-      'Either districtId only, or state + districtType + districtName, or state only',
-    )
+    ).toThrow()
   })
 
   it('rejects statewide district with mismatched districtName', () => {

--- a/src/people/people.schema.ts
+++ b/src/people/people.schema.ts
@@ -4,65 +4,106 @@ import { z } from 'zod'
 
 import { filtersSchema } from './schemas/filters.schema'
 
-// ---- Shared atoms to keep schemas DRY ----
+export const STATE_DISTRICT_TYPE = 'State'
+
 const stateSchema = z.preprocess(
   (v) => (typeof v === 'string' ? v.toUpperCase() : v),
   z.nativeEnum(USState),
 )
 
-export const listPeopleSchema = z.object({
-  state: stateSchema,
-  districtType: z.string().optional(),
-  districtName: z.string().optional(),
-  filters: filtersSchema,
-  search: z.string().optional(),
-  resultsPerPage: z.coerce.number().optional().default(50),
-  page: z.coerce.number().optional().default(1),
-})
+const districtIdSchema = z.string().uuid().optional()
+
+const districtEitherRefine = (v: {
+  districtId?: string
+  state?: string
+  districtType?: string
+  districtName?: string
+}) =>
+  (!!v.districtId && !v.districtType && !v.districtName) ||
+  (!!v.state && !!v.districtType && !!v.districtName) ||
+  (!!v.state && !v.districtId && !v.districtType && !v.districtName)
+
+const districtEitherMessage =
+  'Either districtId only, or state + districtType + districtName, or state only'
+
+const districtStateNameRefine = (v: {
+  districtType?: string
+  districtName?: string
+  state?: string
+}) =>
+  v.districtType !== STATE_DISTRICT_TYPE ||
+  (v.districtName != null && v.state != null && v.districtName === v.state)
+
+const districtStateNameMessage =
+  'When districtType is State, districtName must equal state'
+
+const statsDistrictRefine = (v: {
+  districtId?: string
+  state?: string
+  districtType?: string
+  districtName?: string
+}) =>
+  (!!v.districtId && !v.districtType && !v.districtName) ||
+  (!!v.state && !!v.districtType && !!v.districtName)
+
+const statsDistrictMessage =
+  'Either districtId only, or state + districtType + districtName'
+
+export const listPeopleSchema = z
+  .object({
+    state: stateSchema.optional(),
+    districtId: districtIdSchema,
+    districtType: z.string().optional(),
+    districtName: z.string().optional(),
+    filters: filtersSchema,
+    search: z.string().optional(),
+    resultsPerPage: z.coerce.number().optional().default(50),
+    page: z.coerce.number().optional().default(1),
+  })
+  .refine(districtEitherRefine, districtEitherMessage)
+  .refine(districtStateNameRefine, districtStateNameMessage)
 
 export class ListPeopleDTO extends createZodDto(listPeopleSchema) {}
 
 export const downloadPeopleSchema = z
   .object({
-    state: stateSchema,
+    state: stateSchema.optional(),
+    districtId: districtIdSchema,
     districtType: z.string().optional(),
     districtName: z.string().optional(),
     electionLocation: z.string().optional(),
     electionType: z.string().optional(),
     filters: filtersSchema,
   })
-  .refine(
-    (v) =>
-      (!!v.districtType && !!v.districtName) ||
-      (!v.districtType && !v.districtName),
-    'districtType and districtName are required together',
-  )
+  .refine(districtEitherRefine, districtEitherMessage)
+  .refine(districtStateNameRefine, districtStateNameMessage)
 
 export class DownloadPeopleDTO extends createZodDto(downloadPeopleSchema) {}
 
 export class StatsDTO extends createZodDto(
-  z.object({
-    state: stateSchema,
-    districtType: z.string(),
-    districtName: z.string(),
-  }),
+  z
+    .object({
+      state: stateSchema.optional(),
+      districtId: districtIdSchema,
+      districtType: z.string().optional(),
+      districtName: z.string().optional(),
+    })
+    .refine(statsDistrictRefine, statsDistrictMessage)
+    .refine(districtStateNameRefine, districtStateNameMessage),
 ) {}
 
 export const samplePeopleSchema = z
   .object({
-    state: stateSchema,
+    state: stateSchema.optional(),
+    districtId: districtIdSchema,
     districtType: z.string().optional(),
     districtName: z.string().optional(),
     size: z.coerce.number().int().min(1).max(10000).optional().default(500),
     hasCellPhone: z.coerce.boolean().optional(),
     excludeIds: z.array(z.string().uuid()).optional(),
   })
-  .refine(
-    (v) =>
-      (!!v.districtType && !!v.districtName) ||
-      (!v.districtType && !v.districtName),
-    'districtType and districtName are required together',
-  )
+  .refine(districtEitherRefine, districtEitherMessage)
+  .refine(districtStateNameRefine, districtStateNameMessage)
 
 export class SamplePeopleDTO extends createZodDto(samplePeopleSchema) {}
 
@@ -72,20 +113,17 @@ export class GetPersonParamsDTO extends createZodDto(
   }),
 ) {}
 
-export class GetPersonQueryDTO extends createZodDto(
-  z
-    .object({
-      state: stateSchema,
-      districtType: z.string().optional(),
-      districtName: z.string().optional(),
-    })
-    .refine(
-      (v) =>
-        (!!v.districtType && !!v.districtName) ||
-        (!v.districtType && !v.districtName),
-      'districtType and districtName are required together',
-    ),
-) {}
+export const getPersonQuerySchema = z
+  .object({
+    state: stateSchema.optional(),
+    districtId: districtIdSchema,
+    districtType: z.string().optional(),
+    districtName: z.string().optional(),
+  })
+  .refine(districtEitherRefine, districtEitherMessage)
+  .refine(districtStateNameRefine, districtStateNameMessage)
+
+export class GetPersonQueryDTO extends createZodDto(getPersonQuerySchema) {}
 
 export type ListPeopleSchema = z.infer<typeof listPeopleSchema>
 export type DownloadPeopleSchema = z.infer<typeof downloadPeopleSchema>

--- a/src/people/people.schema.ts
+++ b/src/people/people.schema.ts
@@ -32,7 +32,9 @@ const districtStateNameRefine = (v: {
   state?: string
 }) =>
   v.districtType !== STATE_DISTRICT_TYPE ||
-  (v.districtName != null && v.state != null && v.districtName === v.state)
+  (v.districtName != null &&
+    v.state != null &&
+    v.districtName.toUpperCase() === v.state.toUpperCase())
 
 const districtStateNameMessage =
   'When districtType is State, districtName must equal state'

--- a/src/people/people.schema.ts
+++ b/src/people/people.schema.ts
@@ -19,8 +19,8 @@ const districtEitherRefine = (v: {
   districtType?: string
   districtName?: string
 }) =>
-  (!!v.districtId && !v.districtType && !v.districtName) ||
-  (!!v.state && !!v.districtType && !!v.districtName) ||
+  (!!v.districtId && !v.state && !v.districtType && !v.districtName) ||
+  (!!v.state && !v.districtId && !!v.districtType && !!v.districtName) ||
   (!!v.state && !v.districtId && !v.districtType && !v.districtName)
 
 const districtEitherMessage =
@@ -38,19 +38,6 @@ const districtStateNameRefine = (v: {
 
 const districtStateNameMessage =
   'When districtType is State, districtName must equal state'
-
-const statsDistrictRefine = (v: {
-  districtId?: string
-  state?: string
-  districtType?: string
-  districtName?: string
-}) =>
-  (!!v.districtId && !v.districtType && !v.districtName) ||
-  (!!v.state && !!v.districtType && !!v.districtName) ||
-  (!!v.state && !v.districtId && !v.districtType && !v.districtName)
-
-const statsDistrictMessage =
-  'Either districtId only, or state + districtType + districtName, or state only'
 
 const normalizeStateOnlyDistrict = <
   T extends {
@@ -110,7 +97,7 @@ export class StatsDTO extends createZodDto(
       districtType: z.string().optional(),
       districtName: z.string().optional(),
     })
-    .refine(statsDistrictRefine, statsDistrictMessage)
+    .refine(districtEitherRefine, districtEitherMessage)
     .refine(districtStateNameRefine, districtStateNameMessage)
     .transform(normalizeStateOnlyDistrict),
 ) {}

--- a/src/people/people.schema.ts
+++ b/src/people/people.schema.ts
@@ -39,82 +39,46 @@ const districtStateNameRefine = (v: {
 const districtStateNameMessage =
   'When districtType is State, districtName must equal state'
 
-const normalizeStateOnlyDistrict = <
-  T extends {
-    state?: string
-    districtId?: string
-    districtType?: string
-    districtName?: string
-  },
->(
-  v: T,
-): T => {
-  const stateOnly =
-    !!v.state && !v.districtId && !v.districtType && !v.districtName
-  return stateOnly && v.state
-    ? { ...v, districtType: STATE_DISTRICT_TYPE, districtName: v.state }
-    : v
+const districtInputShape = {
+  state: stateSchema.optional(),
+  districtId: districtIdSchema,
+  districtType: z.string().optional(),
+  districtName: z.string().optional(),
 }
 
-export const listPeopleSchema = z
-  .object({
-    state: stateSchema.optional(),
-    districtId: districtIdSchema,
-    districtType: z.string().optional(),
-    districtName: z.string().optional(),
-    filters: filtersSchema,
-    search: z.string().optional(),
-    resultsPerPage: z.coerce.number().optional().default(50),
-    page: z.coerce.number().optional().default(1),
-  })
-  .refine(districtEitherRefine, districtEitherMessage)
-  .refine(districtStateNameRefine, districtStateNameMessage)
-  .transform(normalizeStateOnlyDistrict)
-
-export class ListPeopleDTO extends createZodDto(listPeopleSchema) {}
-
-export const downloadPeopleSchema = z
-  .object({
-    state: stateSchema.optional(),
-    districtId: districtIdSchema,
-    districtType: z.string().optional(),
-    districtName: z.string().optional(),
-    electionLocation: z.string().optional(),
-    electionType: z.string().optional(),
-    filters: filtersSchema,
-  })
-  .refine(districtEitherRefine, districtEitherMessage)
-  .refine(districtStateNameRefine, districtStateNameMessage)
-  .transform(normalizeStateOnlyDistrict)
-
-export class DownloadPeopleDTO extends createZodDto(downloadPeopleSchema) {}
-
-export class StatsDTO extends createZodDto(
+const withDistrictInput = <T extends z.ZodRawShape>(shape: T) =>
   z
     .object({
-      state: stateSchema.optional(),
-      districtId: districtIdSchema,
-      districtType: z.string().optional(),
-      districtName: z.string().optional(),
+      ...districtInputShape,
+      ...shape,
     })
     .refine(districtEitherRefine, districtEitherMessage)
     .refine(districtStateNameRefine, districtStateNameMessage)
-    .transform(normalizeStateOnlyDistrict),
-) {}
 
-export const samplePeopleSchema = z
-  .object({
-    state: stateSchema.optional(),
-    districtId: districtIdSchema,
-    districtType: z.string().optional(),
-    districtName: z.string().optional(),
-    size: z.coerce.number().int().min(1).max(10000).optional().default(500),
-    hasCellPhone: z.coerce.boolean().optional(),
-    excludeIds: z.array(z.string().uuid()).optional(),
-  })
-  .refine(districtEitherRefine, districtEitherMessage)
-  .refine(districtStateNameRefine, districtStateNameMessage)
-  .transform(normalizeStateOnlyDistrict)
+export const listPeopleSchema = withDistrictInput({
+  filters: filtersSchema,
+  search: z.string().optional(),
+  resultsPerPage: z.coerce.number().optional().default(50),
+  page: z.coerce.number().optional().default(1),
+})
+
+export class ListPeopleDTO extends createZodDto(listPeopleSchema) {}
+
+export const downloadPeopleSchema = withDistrictInput({
+  electionLocation: z.string().optional(),
+  electionType: z.string().optional(),
+  filters: filtersSchema,
+})
+
+export class DownloadPeopleDTO extends createZodDto(downloadPeopleSchema) {}
+
+export class StatsDTO extends createZodDto(withDistrictInput({})) {}
+
+export const samplePeopleSchema = withDistrictInput({
+  size: z.coerce.number().int().min(1).max(10000).optional().default(500),
+  hasCellPhone: z.coerce.boolean().optional(),
+  excludeIds: z.array(z.string().uuid()).optional(),
+})
 
 export class SamplePeopleDTO extends createZodDto(samplePeopleSchema) {}
 
@@ -124,16 +88,7 @@ export class GetPersonParamsDTO extends createZodDto(
   }),
 ) {}
 
-export const getPersonQuerySchema = z
-  .object({
-    state: stateSchema.optional(),
-    districtId: districtIdSchema,
-    districtType: z.string().optional(),
-    districtName: z.string().optional(),
-  })
-  .refine(districtEitherRefine, districtEitherMessage)
-  .refine(districtStateNameRefine, districtStateNameMessage)
-  .transform(normalizeStateOnlyDistrict)
+export const getPersonQuerySchema = withDistrictInput({})
 
 export class GetPersonQueryDTO extends createZodDto(getPersonQuerySchema) {}
 

--- a/src/people/people.schema.ts
+++ b/src/people/people.schema.ts
@@ -46,10 +46,28 @@ const statsDistrictRefine = (v: {
   districtName?: string
 }) =>
   (!!v.districtId && !v.districtType && !v.districtName) ||
-  (!!v.state && !!v.districtType && !!v.districtName)
+  (!!v.state && !!v.districtType && !!v.districtName) ||
+  (!!v.state && !v.districtId && !v.districtType && !v.districtName)
 
 const statsDistrictMessage =
-  'Either districtId only, or state + districtType + districtName'
+  'Either districtId only, or state + districtType + districtName, or state only'
+
+const normalizeStateOnlyDistrict = <
+  T extends {
+    state?: string
+    districtId?: string
+    districtType?: string
+    districtName?: string
+  },
+>(
+  v: T,
+): T => {
+  const stateOnly =
+    !!v.state && !v.districtId && !v.districtType && !v.districtName
+  return stateOnly && v.state
+    ? { ...v, districtType: STATE_DISTRICT_TYPE, districtName: v.state }
+    : v
+}
 
 export const listPeopleSchema = z
   .object({
@@ -64,6 +82,7 @@ export const listPeopleSchema = z
   })
   .refine(districtEitherRefine, districtEitherMessage)
   .refine(districtStateNameRefine, districtStateNameMessage)
+  .transform(normalizeStateOnlyDistrict)
 
 export class ListPeopleDTO extends createZodDto(listPeopleSchema) {}
 
@@ -79,6 +98,7 @@ export const downloadPeopleSchema = z
   })
   .refine(districtEitherRefine, districtEitherMessage)
   .refine(districtStateNameRefine, districtStateNameMessage)
+  .transform(normalizeStateOnlyDistrict)
 
 export class DownloadPeopleDTO extends createZodDto(downloadPeopleSchema) {}
 
@@ -91,7 +111,8 @@ export class StatsDTO extends createZodDto(
       districtName: z.string().optional(),
     })
     .refine(statsDistrictRefine, statsDistrictMessage)
-    .refine(districtStateNameRefine, districtStateNameMessage),
+    .refine(districtStateNameRefine, districtStateNameMessage)
+    .transform(normalizeStateOnlyDistrict),
 ) {}
 
 export const samplePeopleSchema = z
@@ -106,6 +127,7 @@ export const samplePeopleSchema = z
   })
   .refine(districtEitherRefine, districtEitherMessage)
   .refine(districtStateNameRefine, districtStateNameMessage)
+  .transform(normalizeStateOnlyDistrict)
 
 export class SamplePeopleDTO extends createZodDto(samplePeopleSchema) {}
 
@@ -124,6 +146,7 @@ export const getPersonQuerySchema = z
   })
   .refine(districtEitherRefine, districtEitherMessage)
   .refine(districtStateNameRefine, districtStateNameMessage)
+  .transform(normalizeStateOnlyDistrict)
 
 export class GetPersonQueryDTO extends createZodDto(getPersonQuerySchema) {}
 

--- a/src/people/services/people.service.test.ts
+++ b/src/people/services/people.service.test.ts
@@ -1,0 +1,289 @@
+import { NotFoundException } from '@nestjs/common'
+import { PassThrough } from 'stream'
+import { describe, expect, it, beforeEach, vi } from 'vitest'
+import { PeopleService } from './people.service'
+
+const makeDbPerson = (overrides: Record<string, unknown> = {}) =>
+  ({
+    id: 'person-1',
+    LALVOTERID: 'lal-1',
+    State: 'WY',
+    FirstName: 'Jane',
+    MiddleName: null,
+    LastName: 'Doe',
+    NameSuffix: null,
+    Residence_Addresses_AddressLine: null,
+    Residence_Addresses_ExtraAddressLine: null,
+    Residence_Addresses_City: null,
+    Residence_Addresses_State: 'WY',
+    Residence_Addresses_Zip: null,
+    Residence_Addresses_ZipPlus4: null,
+    Mailing_Addresses_AddressLine: null,
+    Mailing_Addresses_ExtraAddressLine: null,
+    Mailing_Addresses_City: null,
+    Mailing_Addresses_State: null,
+    Mailing_Addresses_Zip: null,
+    Mailing_Addresses_ZipPlus4: null,
+    Residence_Addresses_Latitude: null,
+    Residence_Addresses_Longitude: null,
+    VoterTelephones_LandlineFormatted: null,
+    VoterTelephones_CellPhoneFormatted: null,
+    Age: null,
+    Gender: null,
+    Parties_Description: null,
+    Business_Owner: null,
+    Education_Of_Person: null,
+    Estimated_Income_Amount_Int: null,
+    Homeowner_Probability_Model: null,
+    Language_Code: null,
+    Marital_Status: null,
+    Presence_Of_Children: null,
+    Veteran_Status: null,
+    Voter_Status: null,
+    EthnicGroups_EthnicGroup1Desc: null,
+    Age_Int: null,
+    VotingPerformanceEvenYearGeneral: null,
+    VotingPerformanceMinorElection: null,
+    ...overrides,
+  }) as never
+
+describe('PeopleService', () => {
+  let service: PeopleService
+  let mockSampleService: { samplePeople: ReturnType<typeof vi.fn> }
+  let mockDistrictService: {
+    findDistrictById: ReturnType<typeof vi.fn>
+    findDistrictId: ReturnType<typeof vi.fn>
+  }
+  let mockStatsService: {
+    getTotalCounts: ReturnType<typeof vi.fn>
+  }
+  let mockClient: {
+    $queryRaw: ReturnType<typeof vi.fn>
+  }
+
+  beforeEach(() => {
+    mockSampleService = {
+      samplePeople: vi.fn().mockResolvedValue([]),
+    }
+    mockDistrictService = {
+      findDistrictById: vi.fn().mockResolvedValue({
+        id: '0e5bafca-93a9-86a5-2522-f373979720df',
+        type: 'City_Ward',
+        name: 'CHEYENNE CITY WARD 1',
+        state: 'WY',
+      }),
+      findDistrictId: vi.fn().mockResolvedValue('district-by-type-name'),
+    }
+    mockStatsService = {
+      getTotalCounts: vi.fn().mockResolvedValue({
+        totalConstituents: 120,
+        totalConstituentsWithCellPhone: 80,
+      }),
+    }
+    mockClient = {
+      $queryRaw: vi.fn(),
+    }
+
+    service = new PeopleService(
+      mockSampleService as never,
+      mockDistrictService as never,
+      mockStatsService as never,
+    )
+
+    Object.defineProperty(service, '_prisma', {
+      get: () => mockClient,
+      configurable: true,
+    })
+  })
+
+  describe('findPeople query modes and pagination', () => {
+    it('uses districtId-only path via findDistrictById and fast count path', async () => {
+      mockClient.$queryRaw.mockResolvedValueOnce([makeDbPerson()])
+
+      const result = await service.findPeople({
+        districtId: '0e5bafca-93a9-86a5-2522-f373979720df',
+        filters: { filters: [], filterOperators: {} },
+        resultsPerPage: 10,
+        page: 1,
+      } as never)
+
+      expect(mockDistrictService.findDistrictById).toHaveBeenCalledWith(
+        '0e5bafca-93a9-86a5-2522-f373979720df',
+      )
+      expect(mockDistrictService.findDistrictId).not.toHaveBeenCalled()
+      expect(mockStatsService.getTotalCounts).toHaveBeenCalledWith(
+        '0e5bafca-93a9-86a5-2522-f373979720df',
+      )
+      expect(result.pagination.totalResults).toBe(120)
+      expect(result.pagination.totalPages).toBe(12)
+      expect(result.people.length).toBeGreaterThan(0)
+    })
+
+    it('uses state+type+name path via findDistrictId', async () => {
+      mockClient.$queryRaw.mockResolvedValueOnce([makeDbPerson()])
+
+      const result = await service.findPeople({
+        state: 'WY',
+        districtType: 'City_Ward',
+        districtName: 'CHEYENNE CITY WARD 1',
+        filters: { filters: [], filterOperators: {} },
+        resultsPerPage: 10,
+        page: 1,
+      } as never)
+
+      expect(mockDistrictService.findDistrictId).toHaveBeenCalledWith({
+        state: 'WY',
+        type: 'City_Ward',
+        name: 'CHEYENNE CITY WARD 1',
+      })
+      expect(mockStatsService.getTotalCounts).toHaveBeenCalledWith(
+        'district-by-type-name',
+      )
+      expect(result.pagination.totalResults).toBe(120)
+    })
+
+    it('uses voter-only state path when only state is provided', async () => {
+      mockClient.$queryRaw
+        .mockResolvedValueOnce([{ voter_count: 42n }])
+        .mockResolvedValueOnce([makeDbPerson({ id: 'person-2' })])
+
+      const result = await service.findPeople({
+        state: 'WY',
+        filters: { filters: [], filterOperators: {} },
+        resultsPerPage: 10,
+        page: 1,
+      } as never)
+
+      expect(mockDistrictService.findDistrictById).not.toHaveBeenCalled()
+      expect(mockDistrictService.findDistrictId).not.toHaveBeenCalled()
+      expect(mockStatsService.getTotalCounts).not.toHaveBeenCalled()
+      expect(result.pagination.totalResults).toBe(42)
+      expect(result.people[0]?.id).toBe('person-2')
+    })
+
+    it('uses raw count path (not stats shortcut) when search is provided', async () => {
+      mockClient.$queryRaw
+        .mockResolvedValueOnce([{ voter_count: 5n }])
+        .mockResolvedValueOnce([makeDbPerson({ id: 'person-search' })])
+
+      const result = await service.findPeople({
+        districtId: '0e5bafca-93a9-86a5-2522-f373979720df',
+        search: 'jane',
+        filters: { filters: [], filterOperators: {} },
+        resultsPerPage: 10,
+        page: 1,
+      } as never)
+
+      expect(mockStatsService.getTotalCounts).not.toHaveBeenCalled()
+      expect(mockClient.$queryRaw).toHaveBeenCalledTimes(2)
+      expect(result.pagination.totalResults).toBe(5)
+    })
+
+    it('uses raw count path (not stats shortcut) when filters are provided', async () => {
+      mockClient.$queryRaw
+        .mockResolvedValueOnce([{ voter_count: 7n }])
+        .mockResolvedValueOnce([makeDbPerson({ id: 'person-filtered' })])
+
+      const result = await service.findPeople({
+        districtId: '0e5bafca-93a9-86a5-2522-f373979720df',
+        filters: {
+          filters: ['hasCellPhone'],
+          filterOperators: {
+            hasCellPhone: { operator: 'is', value: 'not_null' },
+          },
+        },
+        resultsPerPage: 10,
+        page: 1,
+      } as never)
+
+      expect(mockStatsService.getTotalCounts).not.toHaveBeenCalled()
+      expect(mockClient.$queryRaw).toHaveBeenCalledTimes(2)
+      expect(result.pagination.totalResults).toBe(7)
+    })
+
+    it('clamps currentPage to totalPages when request page is too high', async () => {
+      mockClient.$queryRaw.mockResolvedValueOnce([makeDbPerson()])
+      mockStatsService.getTotalCounts.mockResolvedValue({
+        totalConstituents: 15,
+        totalConstituentsWithCellPhone: 10,
+      })
+
+      const result = await service.findPeople({
+        districtId: '0e5bafca-93a9-86a5-2522-f373979720df',
+        filters: { filters: [], filterOperators: {} },
+        resultsPerPage: 10,
+        page: 99,
+      } as never)
+
+      expect(result.pagination.totalPages).toBe(2)
+      expect(result.pagination.currentPage).toBe(2)
+      expect(result.pagination.hasPreviousPage).toBe(true)
+      expect(result.pagination.hasNextPage).toBe(false)
+    })
+  })
+
+  describe('findPerson', () => {
+    it('returns person for districtId-only path', async () => {
+      mockClient.$queryRaw.mockResolvedValueOnce([makeDbPerson({ id: 'person-ok' })])
+
+      const person = await service.findPerson('person-ok', {
+        districtId: '0e5bafca-93a9-86a5-2522-f373979720df',
+      } as never)
+
+      expect(person.id).toBe('person-ok')
+      expect(person.state).toBe('WY')
+      expect(mockDistrictService.findDistrictById).toHaveBeenCalled()
+    })
+
+    it('returns district-specific not found message for district-bound query', async () => {
+      mockClient.$queryRaw.mockResolvedValueOnce([])
+
+      await expect(
+        service.findPerson('person-1', {
+          districtId: '0e5bafca-93a9-86a5-2522-f373979720df',
+        } as never),
+      ).rejects.toThrow(new NotFoundException('Person not found in district'))
+    })
+
+    it('returns generic not found message for voter-only query', async () => {
+      mockClient.$queryRaw.mockResolvedValueOnce([])
+
+      await expect(
+        service.findPerson('person-1', { state: 'WY' } as never),
+      ).rejects.toThrow(new NotFoundException('Person with ID person-1 not found'))
+    })
+  })
+
+  describe('streamPeopleCsv', () => {
+    it('streams csv with headers, data rows, and election fields', async () => {
+      mockClient.$queryRaw
+        .mockResolvedValueOnce([makeDbPerson({ id: 'stream-1' })])
+        .mockResolvedValueOnce([])
+
+      const raw = new PassThrough()
+      const chunks: Buffer[] = []
+      raw.on('data', (chunk) => {
+        chunks.push(Buffer.from(chunk))
+      })
+      const ended = new Promise<void>((resolve) => raw.on('end', () => resolve()))
+
+      await service.streamPeopleCsv(
+        {
+          districtId: '0e5bafca-93a9-86a5-2522-f373979720df',
+          filters: { filters: [], filterOperators: {} },
+        } as never,
+        {
+          raw,
+        } as never,
+      )
+
+      await ended
+      const csv = Buffer.concat(chunks).toString('utf-8')
+
+      expect(csv).toContain('electionLocation,electionType')
+      expect(csv).toContain('stream-1')
+      expect(csv).toContain('City_Ward')
+      expect(csv).toContain('CHEYENNE CITY WARD 1')
+    })
+  })
+})

--- a/src/people/services/people.service.test.ts
+++ b/src/people/services/people.service.test.ts
@@ -279,11 +279,24 @@ describe('PeopleService', () => {
 
       await ended
       const csv = Buffer.concat(chunks).toString('utf-8')
+      const lines = csv
+        .split('\n')
+        .map((line) => line.trim())
+        .filter((line) => line.length > 0)
+      const header = lines[0].split(',')
+      const data = lines[1].split(',')
+      const electionLocationIdx = header.indexOf('electionLocation')
+      const electionTypeIdx = header.indexOf('electionType')
+      const unquote = (v: string) => v.replace(/^"(.*)"$/, '$1')
 
       expect(csv).toContain('electionLocation,electionType')
       expect(csv).toContain('stream-1')
       expect(csv).toContain('City_Ward')
       expect(csv).toContain('CHEYENNE CITY WARD 1')
+      expect(electionLocationIdx).toBeGreaterThan(-1)
+      expect(electionTypeIdx).toBeGreaterThan(-1)
+      expect(unquote(data[electionLocationIdx])).toBe('CHEYENNE CITY WARD 1')
+      expect(unquote(data[electionTypeIdx])).toBe('City_Ward')
     })
   })
 })

--- a/src/people/services/people.service.ts
+++ b/src/people/services/people.service.ts
@@ -90,6 +90,10 @@ export class PeopleService extends createPrismaBase(MODELS.Voter) {
     const { filters, search, resultsPerPage, page } = dto
     const effectiveDistrictId = useVoterOnlyPath ? null : districtId
 
+    // TODO: This executes count and data query in parallel
+    // for latency, but the data query uses the requested page offset while
+    // currentPage is clamped from totalResults below. If requested page is out
+    // of bounds, pagination metadata and returned rows can diverge.
     const [totalResults, people] = await Promise.all([
       this.rawCountForDistrict({
         state,
@@ -111,8 +115,10 @@ export class PeopleService extends createPrismaBase(MODELS.Voter) {
         }),
       ),
     ])
+
     const totalPages = Math.max(1, Math.ceil(totalResults / resultsPerPage))
     const currentPage = Math.min(Math.max(1, page), totalPages)
+
     return {
       pagination: {
         totalResults,
@@ -208,8 +214,8 @@ export class PeopleService extends createPrismaBase(MODELS.Voter) {
           for (const key of columnNames) {
             row[key] = person[key as keyof typeof person] as CsvValue
           }
-          row.electionLocation = districtType ?? ''
-          row.electionType = districtName ?? ''
+          row.electionLocation = districtName ?? ''
+          row.electionType = districtType ?? ''
 
           const canContinue = csvStream.write(row)
           if (!canContinue) {

--- a/src/people/services/people.service.ts
+++ b/src/people/services/people.service.ts
@@ -290,7 +290,7 @@ export class PeopleService extends createPrismaBase(MODELS.Voter) {
   }): Promise<number> {
     const { state, districtId, search } = args
 
-    if (districtId && !args.search && Object.keys(args.filters).length === 0) {
+    if (districtId && !args.search && args.filters.filters.length === 0) {
       const { totalConstituents } =
         await this.statsService.getTotalCounts(districtId)
       return totalConstituents

--- a/src/people/services/sample.service.test.ts
+++ b/src/people/services/sample.service.test.ts
@@ -116,6 +116,23 @@ describe('SampleService', () => {
     ).rejects.toThrow(BadRequestException)
   })
 
+  it('applies excludeIds against total constituency pool when hasCellPhone=false', async () => {
+    mockStatsService.getTotalCounts.mockResolvedValue({
+      totalConstituents: 100,
+      totalConstituentsWithCellPhone: 10,
+    })
+    wireTransactionResults([[]])
+
+    await expect(
+      service.samplePeople({
+        districtId: '0e5bafca-93a9-86a5-2522-f373979720df',
+        size: 60,
+        hasCellPhone: false,
+        excludeIds: Array.from({ length: 50 }, (_, i) => `exclude-${i}`),
+      }),
+    ).rejects.toThrow(BadRequestException)
+  })
+
   it('retries with a new seed when first sample is underfilled', async () => {
     wireTransactionResults([
       [{ id: 'person-a', State: 'WY' }],

--- a/src/people/services/sample.service.test.ts
+++ b/src/people/services/sample.service.test.ts
@@ -1,0 +1,134 @@
+import { BadRequestException } from '@nestjs/common'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { STATE_DISTRICT_TYPE } from '../people.schema'
+import { SampleService } from './sample.service'
+
+describe('SampleService', () => {
+  let service: SampleService
+  let mockDistrictService: {
+    findDistrictById: ReturnType<typeof vi.fn>
+    findDistrictId: ReturnType<typeof vi.fn>
+  }
+  let mockStatsService: {
+    getTotalCounts: ReturnType<typeof vi.fn>
+  }
+  let mockPrisma: {
+    $transaction: ReturnType<typeof vi.fn>
+  }
+
+  beforeEach(() => {
+    mockDistrictService = {
+      findDistrictById: vi.fn().mockResolvedValue({
+        id: '0e5bafca-93a9-86a5-2522-f373979720df',
+        type: 'City_Ward',
+        name: 'CHEYENNE CITY WARD 1',
+        state: 'WY',
+      }),
+      findDistrictId: vi.fn().mockResolvedValue('statewide-district-id'),
+    }
+
+    mockStatsService = {
+      getTotalCounts: vi.fn().mockResolvedValue({
+        totalConstituents: 5000,
+        totalConstituentsWithCellPhone: 3000,
+      }),
+    }
+
+    mockPrisma = {
+      $transaction: vi.fn(),
+    }
+
+    service = new SampleService(
+      mockDistrictService as never,
+      mockStatsService as never,
+    )
+
+    Object.defineProperty(service, '_prisma', {
+      get: () => mockPrisma,
+      configurable: true,
+    })
+  })
+
+  const wireTransactionResults = (resultsByCall: unknown[][]) => {
+    let call = 0
+    mockPrisma.$transaction.mockImplementation(async (callback: unknown) => {
+      const tx = {
+        $executeRawUnsafe: vi.fn().mockResolvedValue(undefined),
+        $queryRaw: vi.fn().mockResolvedValue(resultsByCall[call++] ?? []),
+      }
+      return (callback as (tx: unknown) => Promise<unknown>)(tx)
+    })
+  }
+
+  it('uses district mode for districtId-only queries', async () => {
+    wireTransactionResults([[{ id: 'person-1', State: 'WY' }]])
+
+    const result = await service.samplePeople({
+      districtId: '0e5bafca-93a9-86a5-2522-f373979720df',
+      size: 1,
+      hasCellPhone: true,
+    })
+
+    expect(mockDistrictService.findDistrictById).toHaveBeenCalledWith(
+      '0e5bafca-93a9-86a5-2522-f373979720df',
+    )
+    expect(mockDistrictService.findDistrictId).not.toHaveBeenCalled()
+    expect(mockStatsService.getTotalCounts).toHaveBeenCalledWith(
+      '0e5bafca-93a9-86a5-2522-f373979720df',
+    )
+    expect(result).toHaveLength(1)
+  })
+
+  it('uses state-only mode and resolves statewide district id when only state is provided', async () => {
+    wireTransactionResults([[{ id: 'person-2', State: 'WY' }]])
+
+    const result = await service.samplePeople({
+      state: 'WY',
+      size: 1,
+      hasCellPhone: false,
+    })
+
+    expect(mockDistrictService.findDistrictById).not.toHaveBeenCalled()
+    expect(mockDistrictService.findDistrictId).toHaveBeenCalledWith({
+      state: 'WY',
+      type: STATE_DISTRICT_TYPE,
+      name: 'WY',
+    })
+    expect(mockStatsService.getTotalCounts).toHaveBeenCalledWith(
+      'statewide-district-id',
+    )
+    expect(result).toHaveLength(1)
+  })
+
+  it('throws when remaining non-excluded constituents are insufficient', async () => {
+    mockStatsService.getTotalCounts.mockResolvedValue({
+      totalConstituents: 10,
+      totalConstituentsWithCellPhone: 8,
+    })
+    wireTransactionResults([[]])
+
+    await expect(
+      service.samplePeople({
+        districtId: '0e5bafca-93a9-86a5-2522-f373979720df',
+        size: 20,
+        hasCellPhone: true,
+      }),
+    ).rejects.toThrow(BadRequestException)
+  })
+
+  it('retries with a new seed when first sample is underfilled', async () => {
+    wireTransactionResults([
+      [{ id: 'person-a', State: 'WY' }],
+      [{ id: 'person-a', State: 'WY' }, { id: 'person-b', State: 'WY' }],
+    ])
+
+    const result = await service.samplePeople({
+      districtId: '0e5bafca-93a9-86a5-2522-f373979720df',
+      size: 2,
+      hasCellPhone: true,
+    })
+
+    expect(mockPrisma.$transaction).toHaveBeenCalledTimes(2)
+    expect(result).toHaveLength(2)
+  })
+})

--- a/src/people/services/sample.service.ts
+++ b/src/people/services/sample.service.ts
@@ -1,12 +1,13 @@
 import { BadRequestException, Injectable } from '@nestjs/common'
 import { Prisma } from '@prisma/client'
 import { createPrismaBase, MODELS } from 'src/prisma/util/prisma.util'
-import { samplePeopleSchema } from '../people.schema'
+import { samplePeopleSchema, STATE_DISTRICT_TYPE } from '../people.schema'
 import { BaseDbPerson, buildVoterSelectSql } from '../people.select'
 import { DistrictService } from 'src/district/services/district.service'
 import { z } from 'zod'
 import { StatsService } from './stats.service'
 import { hash32 } from 'src/shared/util/hash.util'
+import { resolveDistrict } from '../utils/resolveDistrict.utils'
 
 // The comments in this class are not LLM generated, do not remove
 // They are human-written
@@ -77,37 +78,76 @@ export class SampleService extends createPrismaBase(MODELS.Voter) {
   async samplePeople(
     dto: z.output<typeof samplePeopleSchema>,
   ): Promise<BaseDbPerson[]> {
-    const {
-      state,
-      districtType = '',
-      districtName = '',
-      size = 500,
-      hasCellPhone = true,
-      excludeIds = [],
-    } = dto
+    const resolved = await resolveDistrict(this.districtService, dto)
+    const size = dto.size ?? 500
+    const hasCellPhone = dto.hasCellPhone ?? true
+    const excludeIds = dto.excludeIds ?? []
 
-    let districtId = ''
-    if (districtType && districtName) {
-      districtId = await this.districtService.findDistrictId({
-        state,
-        type: districtType,
-        name: districtName,
+    const seed = hash32(
+      `${resolved.districtId ?? resolved.state}:${Date.now() / 60_000}`,
+    )
+
+    const outerWhereClause = this.buildOuterWhereSql(
+      resolved.state,
+      hasCellPhone,
+    )
+    const { sql: voterSelect } = buildVoterSelectSql()
+
+    if (resolved.useVoterOnlyPath) {
+      const stateDistrictId = await this.districtService.findDistrictId({
+        state: resolved.state,
+        type: STATE_DISTRICT_TYPE,
+        name: resolved.state,
       })
+      const { hashDivisor, prelimit } =
+        await this.computeHashDivisorAndPrelimit(
+          stateDistrictId,
+          excludeIds.length,
+          size,
+          hasCellPhone,
+        )
+      const { excludeCte, excludeJoin, excludeWhere } =
+        this.buildAntiJoinStateOnly(excludeIds)
+      const result = await this.runSampleQueryStateOnly({
+        state: resolved.state,
+        hasCellPhone,
+        seed,
+        hashDivisor,
+        outerWhereClause,
+        excludeCte,
+        excludeJoin,
+        excludeWhere,
+        prelimit,
+        voterSelect,
+        size,
+      })
+      if (result.length < size) {
+        const retrySeed = (seed + 1) >>> 0
+        return this.runSampleQueryStateOnly({
+          state: resolved.state,
+          hasCellPhone,
+          seed: retrySeed,
+          hashDivisor,
+          outerWhereClause,
+          excludeCte,
+          excludeJoin,
+          excludeWhere,
+          prelimit,
+          voterSelect,
+          size,
+        })
+      }
+      return result
     }
 
-    const seed = hash32(`${districtId}:${Date.now() / 60_000}`) // Rotates every minute
-
-    const innerWhereClause = this.buildInnerWhereSql(districtId, state)
-    const outerWhereClause = this.buildOuterWhereSql(state, hasCellPhone)
+    const districtId = resolved.districtId!
+    const innerWhereClause = this.buildInnerWhereSql(districtId, resolved.state)
     const { hashDivisor, prelimit } = await this.computeHashDivisorAndPrelimit(
       districtId,
       excludeIds.length,
       size,
       hasCellPhone,
     )
-
-    const { sql: voterSelect } = buildVoterSelectSql()
-
     const { excludeCte, excludeJoin, excludeWhere } =
       this.buildAntiJoin(excludeIds)
     const result = await this.runSampleQuery({
@@ -142,6 +182,81 @@ export class SampleService extends createPrismaBase(MODELS.Voter) {
       return retryResult
     }
     return result
+  }
+
+  private buildStateOnlyInnerWhere(
+    state: string,
+    hasCellPhone?: boolean,
+  ): Prisma.Sql {
+    const parts: Prisma.Sql[] = [
+      Prisma.sql`v."State" = CAST(${state}::text AS public."USState")`,
+    ]
+    if (hasCellPhone === true) {
+      parts.push(Prisma.sql`v."VoterTelephones_CellPhoneFormatted" IS NOT NULL`)
+    } else if (hasCellPhone === false) {
+      parts.push(Prisma.sql`v."VoterTelephones_CellPhoneFormatted" IS NULL`)
+    }
+    return Prisma.sql`WHERE ${Prisma.join(parts, ' AND ')}`
+  }
+
+  private async runSampleQueryStateOnly(args: {
+    state: string
+    hasCellPhone: boolean | undefined
+    seed: number
+    hashDivisor: number
+    outerWhereClause: Prisma.Sql
+    excludeCte: Prisma.Sql
+    excludeJoin: Prisma.Sql
+    excludeWhere: Prisma.Sql
+    prelimit: number
+    voterSelect: Prisma.Sql
+    size: number
+  }): Promise<BaseDbPerson[]> {
+    const {
+      state,
+      hasCellPhone,
+      seed,
+      hashDivisor,
+      outerWhereClause,
+      excludeCte,
+      excludeJoin,
+      excludeWhere,
+      prelimit,
+      voterSelect,
+      size,
+    } = args
+    const hashBuckets = this.makeHashBuckets(hashDivisor, seed)
+    const innerWhere = this.buildStateOnlyInnerWhere(state, hasCellPhone)
+    const rows = (await this.client.$transaction(
+      async (tx) => {
+        await tx.$executeRawUnsafe(`
+        SET LOCAL plan_cache_mode = force_custom_plan;
+      `)
+        return tx.$queryRaw`
+      WITH ${excludeCte} candidate_ids AS (
+        SELECT v.id
+        FROM green."Voter" v
+          ${excludeJoin}
+          ${innerWhere}
+          AND (
+            abs(hashtextextended(v.id::text, ${seed})) % ${hashDivisor}
+          ) = ANY(${hashBuckets}::int[])
+          ${excludeWhere}
+        LIMIT ${prelimit}
+      )
+      ${voterSelect}
+      FROM candidate_ids c
+      JOIN green."Voter" v
+        ON v.id = c.id
+      ${outerWhereClause}
+      LIMIT ${size};
+      `
+      },
+      {
+        timeout: 60_000,
+      },
+    )) as BaseDbPerson[]
+    return rows
   }
 
   private async runSampleQuery(args: {
@@ -253,6 +368,26 @@ export class SampleService extends createPrismaBase(MODELS.Voter) {
     return {
       excludeCte: Prisma.sql`exclude AS (SELECT unnest(${excludeArray}) AS id),`,
       excludeJoin: Prisma.sql`LEFT JOIN exclude e ON e.id = dv.voter_id`,
+      excludeWhere: Prisma.sql`AND e.id IS NULL`,
+    }
+  }
+
+  private buildAntiJoinStateOnly(excludeIds: string[]): {
+    excludeCte: Prisma.Sql
+    excludeJoin: Prisma.Sql
+    excludeWhere: Prisma.Sql
+  } {
+    if (excludeIds.length === 0) {
+      return {
+        excludeCte: Prisma.empty,
+        excludeJoin: Prisma.empty,
+        excludeWhere: Prisma.empty,
+      }
+    }
+    const excludeArray = Prisma.sql`ARRAY[${Prisma.join(excludeIds)}]::uuid[]`
+    return {
+      excludeCte: Prisma.sql`exclude AS (SELECT unnest(${excludeArray}) AS id),`,
+      excludeJoin: Prisma.sql`LEFT JOIN exclude e ON e.id = v.id`,
       excludeWhere: Prisma.sql`AND e.id IS NULL`,
     }
   }

--- a/src/people/services/sample.service.ts
+++ b/src/people/services/sample.service.ts
@@ -55,14 +55,13 @@ export class SampleService extends createPrismaBase(MODELS.Voter) {
   ) {
     const { totalConstituentsWithCellPhone, totalConstituents } =
       await this.statsService.getTotalCounts(districtId)
-    const effectiveExcludeCount = Math.min(
-      excludeIdsSize,
-      totalConstituentsWithCellPhone,
-    )
+    const poolConstituentCount = hasCellPhone
+      ? totalConstituentsWithCellPhone
+      : totalConstituents
+    const effectiveExcludeCount = Math.min(excludeIdsSize, poolConstituentCount)
 
-    const remainingConstituentCount = hasCellPhone
-      ? totalConstituentsWithCellPhone - effectiveExcludeCount
-      : totalConstituents - effectiveExcludeCount
+    const remainingConstituentCount =
+      poolConstituentCount - effectiveExcludeCount
 
     if (remainingConstituentCount < targetSampleSize) {
       throw new BadRequestException(

--- a/src/people/services/sample.service.ts
+++ b/src/people/services/sample.service.ts
@@ -9,6 +9,19 @@ import { StatsService } from './stats.service'
 import { hash32 } from 'src/shared/util/hash.util'
 import { resolveDistrict } from '../utils/resolveDistrict.utils'
 
+type SampleQueryMode =
+  | {
+      kind: 'stateOnly'
+      state: string
+      hasCellPhone: boolean | undefined
+      districtId: string
+    }
+  | {
+      kind: 'district'
+      state: string
+      districtId: string
+    }
+
 // The comments in this class are not LLM generated, do not remove
 // They are human-written
 @Injectable()
@@ -89,68 +102,41 @@ export class SampleService extends createPrismaBase(MODELS.Voter) {
     const outerWhereClause = this.buildOuterWhereSql(state, hasCellPhone)
     const { sql: voterSelect } = buildVoterSelectSql()
 
-    if (useVoterOnlyPath) {
-      const stateDistrictId = await this.districtService.findDistrictId({
-        state,
-        type: STATE_DISTRICT_TYPE,
-        name: state,
-      })
-      const { hashDivisor, prelimit } =
-        await this.computeHashDivisorAndPrelimit(
-          stateDistrictId,
-          excludeIds.length,
-          size,
-          hasCellPhone,
-        )
-      const { excludeCte, excludeJoin, excludeWhere } =
-        this.buildAntiJoinStateOnly(excludeIds)
-      const result = await this.runSampleQueryStateOnly({
-        state,
-        hasCellPhone,
-        seed,
-        hashDivisor,
-        outerWhereClause,
-        excludeCte,
-        excludeJoin,
-        excludeWhere,
-        prelimit,
-        voterSelect,
-        size,
-      })
-      if (result.length < size) {
-        const retrySeed = (seed + 1) >>> 0
-        return this.runSampleQueryStateOnly({
+    const mode: SampleQueryMode = useVoterOnlyPath
+      ? {
+          kind: 'stateOnly',
           state,
           hasCellPhone,
-          seed: retrySeed,
-          hashDivisor,
-          outerWhereClause,
-          excludeCte,
-          excludeJoin,
-          excludeWhere,
-          prelimit,
-          voterSelect,
-          size,
-        })
-      }
-      return result
-    }
+          districtId:
+            resolvedDistrictId ??
+            (await this.districtService.findDistrictId({
+              state,
+              type: STATE_DISTRICT_TYPE,
+              name: state,
+            })),
+        }
+      : {
+          kind: 'district',
+          state,
+          districtId: resolvedDistrictId!,
+        }
 
-    const districtId = resolvedDistrictId!
-    const innerWhereClause = this.buildInnerWhereSql(districtId, state)
     const { hashDivisor, prelimit } = await this.computeHashDivisorAndPrelimit(
-      districtId,
+      mode.districtId,
       excludeIds.length,
       size,
       hasCellPhone,
     )
-    const { excludeCte, excludeJoin, excludeWhere } =
-      this.buildAntiJoin(excludeIds)
+    const excludeIdReference =
+      mode.kind === 'stateOnly' ? Prisma.sql`v.id` : Prisma.sql`dv.voter_id`
+    const { excludeCte, excludeJoin, excludeWhere } = this.buildAntiJoin(
+      excludeIds,
+      excludeIdReference,
+    )
     const result = await this.runSampleQuery({
-      districtId,
+      mode,
       seed,
       hashDivisor,
-      innerWhereClause,
       outerWhereClause,
       excludeCte,
       excludeJoin,
@@ -160,13 +146,16 @@ export class SampleService extends createPrismaBase(MODELS.Voter) {
       size,
     })
     if (result.length < size) {
-      this.logger.warn(`Sampling retry activated for district: ${districtId}`)
+      this.logger.warn(
+        mode.kind === 'district'
+          ? `Sampling retry activated for district: ${mode.districtId}`
+          : `Sampling retry activated for state: ${mode.state}`,
+      )
       const retrySeed = (seed + 1) >>> 0
-      const retryResult = await this.runSampleQuery({
-        districtId,
+      return this.runSampleQuery({
+        mode,
         seed: retrySeed,
         hashDivisor,
-        innerWhereClause,
         outerWhereClause,
         excludeCte,
         excludeJoin,
@@ -175,91 +164,14 @@ export class SampleService extends createPrismaBase(MODELS.Voter) {
         voterSelect,
         size,
       })
-      return retryResult
     }
     return result
   }
 
-  private buildStateOnlyInnerWhere(
-    state: string,
-    hasCellPhone?: boolean,
-  ): Prisma.Sql {
-    const parts: Prisma.Sql[] = [
-      Prisma.sql`v."State" = CAST(${state}::text AS public."USState")`,
-    ]
-    if (hasCellPhone === true) {
-      parts.push(Prisma.sql`v."VoterTelephones_CellPhoneFormatted" IS NOT NULL`)
-    } else if (hasCellPhone === false) {
-      parts.push(Prisma.sql`v."VoterTelephones_CellPhoneFormatted" IS NULL`)
-    }
-    return Prisma.sql`WHERE ${Prisma.join(parts, ' AND ')}`
-  }
-
-  private async runSampleQueryStateOnly(args: {
-    state: string
-    hasCellPhone: boolean | undefined
-    seed: number
-    hashDivisor: number
-    outerWhereClause: Prisma.Sql
-    excludeCte: Prisma.Sql
-    excludeJoin: Prisma.Sql
-    excludeWhere: Prisma.Sql
-    prelimit: number
-    voterSelect: Prisma.Sql
-    size: number
-  }): Promise<BaseDbPerson[]> {
-    const {
-      state,
-      hasCellPhone,
-      seed,
-      hashDivisor,
-      outerWhereClause,
-      excludeCte,
-      excludeJoin,
-      excludeWhere,
-      prelimit,
-      voterSelect,
-      size,
-    } = args
-    const hashBuckets = this.makeHashBuckets(hashDivisor, seed)
-    const innerWhere = this.buildStateOnlyInnerWhere(state, hasCellPhone)
-    const rows = (await this.client.$transaction(
-      async (tx) => {
-        await tx.$executeRawUnsafe(`
-        SET LOCAL plan_cache_mode = force_custom_plan;
-      `)
-        return tx.$queryRaw`
-      WITH ${excludeCte} candidate_ids AS (
-        SELECT v.id
-        FROM green."Voter" v
-          ${excludeJoin}
-          ${innerWhere}
-          AND (
-            abs(hashtextextended(v.id::text, ${seed})) % ${hashDivisor}
-          ) = ANY(${hashBuckets}::int[])
-          ${excludeWhere}
-        LIMIT ${prelimit}
-      )
-      ${voterSelect}
-      FROM candidate_ids c
-      JOIN green."Voter" v
-        ON v.id = c.id
-      ${outerWhereClause}
-      LIMIT ${size};
-      `
-      },
-      {
-        timeout: 60_000,
-      },
-    )) as BaseDbPerson[]
-    return rows
-  }
-
   private async runSampleQuery(args: {
-    districtId: string
+    mode: SampleQueryMode
     seed: number
     hashDivisor: number
-    innerWhereClause: Prisma.Sql
     outerWhereClause: Prisma.Sql
     excludeCte: Prisma.Sql
     excludeJoin: Prisma.Sql
@@ -269,10 +181,9 @@ export class SampleService extends createPrismaBase(MODELS.Voter) {
     size: number
   }): Promise<BaseDbPerson[]> {
     const {
-      districtId,
+      mode,
       seed,
       hashDivisor,
-      innerWhereClause,
       outerWhereClause,
       excludeCte,
       excludeJoin,
@@ -282,13 +193,33 @@ export class SampleService extends createPrismaBase(MODELS.Voter) {
       size,
     } = args
     const hashBuckets = this.makeHashBuckets(hashDivisor, seed)
-    this.logger.debug(`
+    if (mode.kind === 'district') {
+      this.logger.debug(`
       Querying for sample buckets.
-      districtId: ${districtId}
+      districtId: ${mode.districtId}
       hashBuckets: ${hashBuckets.toString()}
       hashDivisor: ${hashDivisor}
       seed: ${seed}
       `)
+    }
+    const candidateIdReference =
+      mode.kind === 'stateOnly' ? Prisma.sql`v.id` : Prisma.sql`dv.voter_id`
+    const innerWhereClause =
+      mode.kind === 'stateOnly'
+        ? this.buildInnerWhereSql({
+            state: mode.state,
+            stateOnly: true,
+            hasCellPhone: mode.hasCellPhone,
+          })
+        : this.buildInnerWhereSql({
+            state: mode.state,
+            districtId: mode.districtId,
+            stateOnly: false,
+          })
+    const sourceFromClause =
+      mode.kind === 'stateOnly'
+        ? Prisma.sql`FROM green."Voter" v`
+        : Prisma.sql`FROM green."DistrictVoter" dv`
     const rows = (await this.client.$transaction(
       async (tx) => {
         await tx.$executeRawUnsafe(`
@@ -296,8 +227,8 @@ export class SampleService extends createPrismaBase(MODELS.Voter) {
       `)
         return tx.$queryRaw`
       WITH ${excludeCte} candidate_ids AS (
-        SELECT dv.voter_id AS id
-        FROM green."DistrictVoter" dv
+        SELECT ${candidateIdReference} AS id
+        ${sourceFromClause}
           ${excludeJoin}
           ${innerWhereClause}
       
@@ -306,7 +237,7 @@ export class SampleService extends createPrismaBase(MODELS.Voter) {
           -- A row only passes this filter if it's bucket is in hashBuckets
           -- Ex: hashDivisor = 2000, bucketCount - 3, we select 3/2000 = ~0.15%
           AND (
-            abs(hashtextextended(dv.voter_id::text, ${seed})) % ${hashDivisor}
+            abs(hashtextextended(${candidateIdReference}::text, ${seed})) % ${hashDivisor}
           ) = ANY(${hashBuckets}::int[])
       
           -- cheap hash anti-join (exclude ids)
@@ -346,7 +277,10 @@ export class SampleService extends createPrismaBase(MODELS.Voter) {
     return buckets
   }
 
-  private buildAntiJoin(excludeIds: string[]): {
+  private buildAntiJoin(
+    excludeIds: string[],
+    idReference: Prisma.Sql,
+  ): {
     excludeCte: Prisma.Sql
     excludeJoin: Prisma.Sql
     excludeWhere: Prisma.Sql
@@ -363,27 +297,7 @@ export class SampleService extends createPrismaBase(MODELS.Voter) {
 
     return {
       excludeCte: Prisma.sql`exclude AS (SELECT unnest(${excludeArray}) AS id),`,
-      excludeJoin: Prisma.sql`LEFT JOIN exclude e ON e.id = dv.voter_id`,
-      excludeWhere: Prisma.sql`AND e.id IS NULL`,
-    }
-  }
-
-  private buildAntiJoinStateOnly(excludeIds: string[]): {
-    excludeCte: Prisma.Sql
-    excludeJoin: Prisma.Sql
-    excludeWhere: Prisma.Sql
-  } {
-    if (excludeIds.length === 0) {
-      return {
-        excludeCte: Prisma.empty,
-        excludeJoin: Prisma.empty,
-        excludeWhere: Prisma.empty,
-      }
-    }
-    const excludeArray = Prisma.sql`ARRAY[${Prisma.join(excludeIds)}]::uuid[]`
-    return {
-      excludeCte: Prisma.sql`exclude AS (SELECT unnest(${excludeArray}) AS id),`,
-      excludeJoin: Prisma.sql`LEFT JOIN exclude e ON e.id = v.id`,
+      excludeJoin: Prisma.sql`LEFT JOIN exclude e ON e.id = ${idReference}`,
       excludeWhere: Prisma.sql`AND e.id IS NULL`,
     }
   }
@@ -408,9 +322,28 @@ export class SampleService extends createPrismaBase(MODELS.Voter) {
     return Prisma.sql`WHERE ${Prisma.join(whereParts, ' AND ')}`
   }
 
-  private buildInnerWhereSql(districtId: string, state: string): Prisma.Sql {
+  private buildInnerWhereSql(args: {
+    state: string
+    stateOnly: boolean
+    districtId?: string
+    hasCellPhone?: boolean
+  }): Prisma.Sql {
+    const { state, stateOnly, districtId, hasCellPhone } = args
     const whereParts: Prisma.Sql[] = []
-    if (districtId && state) {
+    if (stateOnly) {
+      whereParts.push(
+        Prisma.sql`v."State" = CAST(${state}::text AS public."USState")`,
+      )
+      if (hasCellPhone === true) {
+        whereParts.push(
+          Prisma.sql`v."VoterTelephones_CellPhoneFormatted" IS NOT NULL`,
+        )
+      } else if (hasCellPhone === false) {
+        whereParts.push(
+          Prisma.sql`v."VoterTelephones_CellPhoneFormatted" IS NULL`,
+        )
+      }
+    } else if (districtId && state) {
       whereParts.push(Prisma.sql`dv.district_id = ${districtId}::uuid`)
       whereParts.push(
         Prisma.sql`dv."State" = CAST(${state}::text AS public."USState")`,

--- a/src/people/services/sample.service.ts
+++ b/src/people/services/sample.service.ts
@@ -22,6 +22,13 @@ type SampleQueryMode =
       districtId: string
     }
 
+interface SampleQueryFragments {
+  sourceFromClause: Prisma.Sql
+  candidateIdReference: Prisma.Sql
+  excludeIdReference: Prisma.Sql
+  innerWhereClause: Prisma.Sql
+}
+
 // The comments in this class are not LLM generated, do not remove
 // They are human-written
 @Injectable()
@@ -120,21 +127,22 @@ export class SampleService extends createPrismaBase(MODELS.Voter) {
           state,
           districtId: resolvedDistrictId!,
         }
+    const { districtId } = mode
 
     const { hashDivisor, prelimit } = await this.computeHashDivisorAndPrelimit(
-      mode.districtId,
+      districtId,
       excludeIds.length,
       size,
       hasCellPhone,
     )
-    const excludeIdReference =
-      mode.kind === 'stateOnly' ? Prisma.sql`v.id` : Prisma.sql`dv.voter_id`
+    const queryFragments = this.buildSampleQueryFragments(mode)
     const { excludeCte, excludeJoin, excludeWhere } = this.buildAntiJoin(
       excludeIds,
-      excludeIdReference,
+      queryFragments.excludeIdReference,
     )
     const result = await this.runSampleQuery({
       mode,
+      queryFragments,
       seed,
       hashDivisor,
       outerWhereClause,
@@ -146,14 +154,16 @@ export class SampleService extends createPrismaBase(MODELS.Voter) {
       size,
     })
     if (result.length < size) {
+      const { kind, state: modeState, districtId: modeDistrictId } = mode
       this.logger.warn(
-        mode.kind === 'district'
-          ? `Sampling retry activated for district: ${mode.districtId}`
-          : `Sampling retry activated for state: ${mode.state}`,
+        kind === 'district'
+          ? `Sampling retry activated for district: ${modeDistrictId}`
+          : `Sampling retry activated for state: ${modeState}`,
       )
       const retrySeed = (seed + 1) >>> 0
       return this.runSampleQuery({
         mode,
+        queryFragments,
         seed: retrySeed,
         hashDivisor,
         outerWhereClause,
@@ -170,6 +180,7 @@ export class SampleService extends createPrismaBase(MODELS.Voter) {
 
   private async runSampleQuery(args: {
     mode: SampleQueryMode
+    queryFragments: SampleQueryFragments
     seed: number
     hashDivisor: number
     outerWhereClause: Prisma.Sql
@@ -182,6 +193,7 @@ export class SampleService extends createPrismaBase(MODELS.Voter) {
   }): Promise<BaseDbPerson[]> {
     const {
       mode,
+      queryFragments,
       seed,
       hashDivisor,
       outerWhereClause,
@@ -192,34 +204,17 @@ export class SampleService extends createPrismaBase(MODELS.Voter) {
       voterSelect,
       size,
     } = args
+    const { kind, districtId } = mode
     const hashBuckets = this.makeHashBuckets(hashDivisor, seed)
-    if (mode.kind === 'district') {
+    if (kind === 'district') {
       this.logger.debug(`
       Querying for sample buckets.
-      districtId: ${mode.districtId}
+      districtId: ${districtId}
       hashBuckets: ${hashBuckets.toString()}
       hashDivisor: ${hashDivisor}
       seed: ${seed}
       `)
     }
-    const candidateIdReference =
-      mode.kind === 'stateOnly' ? Prisma.sql`v.id` : Prisma.sql`dv.voter_id`
-    const innerWhereClause =
-      mode.kind === 'stateOnly'
-        ? this.buildInnerWhereSql({
-            state: mode.state,
-            stateOnly: true,
-            hasCellPhone: mode.hasCellPhone,
-          })
-        : this.buildInnerWhereSql({
-            state: mode.state,
-            districtId: mode.districtId,
-            stateOnly: false,
-          })
-    const sourceFromClause =
-      mode.kind === 'stateOnly'
-        ? Prisma.sql`FROM green."Voter" v`
-        : Prisma.sql`FROM green."DistrictVoter" dv`
     const rows = (await this.client.$transaction(
       async (tx) => {
         await tx.$executeRawUnsafe(`
@@ -227,17 +222,17 @@ export class SampleService extends createPrismaBase(MODELS.Voter) {
       `)
         return tx.$queryRaw`
       WITH ${excludeCte} candidate_ids AS (
-        SELECT ${candidateIdReference} AS id
-        ${sourceFromClause}
+        SELECT ${queryFragments.candidateIdReference} AS id
+        ${queryFragments.sourceFromClause}
           ${excludeJoin}
-          ${innerWhereClause}
+          ${queryFragments.innerWhereClause}
       
           -- PRE CUT - Divides all of the voterIds into buckets
           -- Number of buckets is our hashDivisor
           -- A row only passes this filter if it's bucket is in hashBuckets
           -- Ex: hashDivisor = 2000, bucketCount - 3, we select 3/2000 = ~0.15%
           AND (
-            abs(hashtextextended(${candidateIdReference}::text, ${seed})) % ${hashDivisor}
+            abs(hashtextextended(${queryFragments.candidateIdReference}::text, ${seed})) % ${hashDivisor}
           ) = ANY(${hashBuckets}::int[])
       
           -- cheap hash anti-join (exclude ids)
@@ -258,6 +253,26 @@ export class SampleService extends createPrismaBase(MODELS.Voter) {
       },
     )) as BaseDbPerson[]
     return rows
+  }
+
+  private buildSampleQueryFragments(
+    mode: SampleQueryMode,
+  ): SampleQueryFragments {
+    const { kind } = mode
+    if (kind === 'stateOnly') {
+      return {
+        sourceFromClause: Prisma.sql`FROM green."Voter" v`,
+        candidateIdReference: Prisma.sql`v.id`,
+        excludeIdReference: Prisma.sql`v.id`,
+        innerWhereClause: this.buildInnerWhereSql(mode),
+      }
+    }
+    return {
+      sourceFromClause: Prisma.sql`FROM green."DistrictVoter" dv`,
+      candidateIdReference: Prisma.sql`dv.voter_id`,
+      excludeIdReference: Prisma.sql`dv.voter_id`,
+      innerWhereClause: this.buildInnerWhereSql(mode),
+    }
   }
 
   private makeHashBuckets(hashDivisor: number, seed32: number): number[] {
@@ -322,15 +337,11 @@ export class SampleService extends createPrismaBase(MODELS.Voter) {
     return Prisma.sql`WHERE ${Prisma.join(whereParts, ' AND ')}`
   }
 
-  private buildInnerWhereSql(args: {
-    state: string
-    stateOnly: boolean
-    districtId?: string
-    hasCellPhone?: boolean
-  }): Prisma.Sql {
-    const { state, stateOnly, districtId, hasCellPhone } = args
+  private buildInnerWhereSql(mode: SampleQueryMode): Prisma.Sql {
+    const { kind, state } = mode
     const whereParts: Prisma.Sql[] = []
-    if (stateOnly) {
+    if (kind === 'stateOnly') {
+      const { hasCellPhone } = mode
       whereParts.push(
         Prisma.sql`v."State" = CAST(${state}::text AS public."USState")`,
       )
@@ -343,7 +354,8 @@ export class SampleService extends createPrismaBase(MODELS.Voter) {
           Prisma.sql`v."VoterTelephones_CellPhoneFormatted" IS NULL`,
         )
       }
-    } else if (districtId && state) {
+    } else if (mode.districtId && state) {
+      const { districtId } = mode
       whereParts.push(Prisma.sql`dv.district_id = ${districtId}::uuid`)
       whereParts.push(
         Prisma.sql`dv."State" = CAST(${state}::text AS public."USState")`,

--- a/src/people/services/stats.service.test.ts
+++ b/src/people/services/stats.service.test.ts
@@ -1,0 +1,104 @@
+import { NotFoundException } from '@nestjs/common'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { StatsService } from './stats.service'
+
+describe('StatsService', () => {
+  let service: StatsService
+  let mockDistrictService: {
+    findDistrictId: ReturnType<typeof vi.fn>
+  }
+  let mockPrisma: {
+    districtStats: {
+      findUnique: ReturnType<typeof vi.fn>
+    }
+  }
+
+  beforeEach(() => {
+    mockDistrictService = {
+      findDistrictId: vi.fn().mockResolvedValue('district-by-type-name'),
+    }
+    mockPrisma = {
+      districtStats: {
+        findUnique: vi.fn(),
+      },
+    }
+
+    service = new StatsService(mockDistrictService as never)
+    Object.defineProperty(service, '_prisma', {
+      get: () => mockPrisma,
+      configurable: true,
+    })
+  })
+
+  it('uses districtId directly when provided', async () => {
+    mockPrisma.districtStats.findUnique.mockResolvedValue({
+      districtId: 'district-1',
+      totalConstituents: 100,
+    })
+
+    const result = await service.getStats({
+      districtId: 'district-1',
+    } as never)
+
+    expect(mockDistrictService.findDistrictId).not.toHaveBeenCalled()
+    expect(mockPrisma.districtStats.findUnique).toHaveBeenCalledWith({
+      where: { districtId: 'district-1' },
+    })
+    expect(result.districtId).toBe('district-1')
+  })
+
+  it('resolves districtId from state/type/name when districtId is absent', async () => {
+    mockPrisma.districtStats.findUnique.mockResolvedValue({
+      districtId: 'district-by-type-name',
+      totalConstituents: 200,
+    })
+
+    const result = await service.getStats({
+      state: 'WY',
+      districtType: 'City_Ward',
+      districtName: 'CHEYENNE CITY WARD 1',
+    } as never)
+
+    expect(mockDistrictService.findDistrictId).toHaveBeenCalledWith({
+      state: 'WY',
+      type: 'City_Ward',
+      name: 'CHEYENNE CITY WARD 1',
+    })
+    expect(result.districtId).toBe('district-by-type-name')
+  })
+
+  it('throws NotFoundException when stats are missing', async () => {
+    mockPrisma.districtStats.findUnique.mockResolvedValue(null)
+
+    await expect(
+      service.getStats({ districtId: 'missing-district-id' } as never),
+    ).rejects.toThrow(NotFoundException)
+  })
+
+  it('returns total counts for a district', async () => {
+    mockPrisma.districtStats.findUnique.mockResolvedValue({
+      totalConstituents: 111,
+      totalConstituentsWithCellPhone: 55,
+    })
+
+    const counts = await service.getTotalCounts('district-1')
+
+    expect(mockPrisma.districtStats.findUnique).toHaveBeenCalledWith({
+      select: {
+        totalConstituents: true,
+        totalConstituentsWithCellPhone: true,
+      },
+      where: { districtId: 'district-1' },
+    })
+    expect(counts.totalConstituents).toBe(111)
+    expect(counts.totalConstituentsWithCellPhone).toBe(55)
+  })
+
+  it('throws when total counts are missing', async () => {
+    mockPrisma.districtStats.findUnique.mockResolvedValue(null)
+
+    await expect(service.getTotalCounts('missing-district-id')).rejects.toThrow(
+      NotFoundException,
+    )
+  })
+})

--- a/src/people/services/stats.service.test.ts
+++ b/src/people/services/stats.service.test.ts
@@ -67,6 +67,24 @@ describe('StatsService', () => {
     expect(result.districtId).toBe('district-by-type-name')
   })
 
+  it('resolves districtId from state-only using statewide district', async () => {
+    mockPrisma.districtStats.findUnique.mockResolvedValue({
+      districtId: 'district-by-type-name',
+      totalConstituents: 250,
+    })
+
+    const result = await service.getStats({
+      state: 'WY',
+    } as never)
+
+    expect(mockDistrictService.findDistrictId).toHaveBeenCalledWith({
+      state: 'WY',
+      type: 'State',
+      name: 'WY',
+    })
+    expect(result.districtId).toBe('district-by-type-name')
+  })
+
   it('throws NotFoundException when stats are missing', async () => {
     mockPrisma.districtStats.findUnique.mockResolvedValue(null)
 

--- a/src/people/services/stats.service.ts
+++ b/src/people/services/stats.service.ts
@@ -11,12 +11,13 @@ export class StatsService extends createPrismaBase(MODELS.DistrictStats) {
   }
 
   async getStats(dto: StatsDTO): Promise<DistrictStats> {
-    const districtId = dto.districtId
-      ? dto.districtId
+    const { districtId: dtoDistrictId, state, districtType, districtName } = dto
+    const districtId = dtoDistrictId
+      ? dtoDistrictId
       : await this.districtService.findDistrictId({
-          state: dto.state!,
-          type: dto.districtType!,
-          name: dto.districtName!,
+          state: state!,
+          type: districtType!,
+          name: districtName!,
         })
     const stats = await this.model.findUnique({ where: { districtId } })
 

--- a/src/people/services/stats.service.ts
+++ b/src/people/services/stats.service.ts
@@ -10,16 +10,14 @@ export class StatsService extends createPrismaBase(MODELS.DistrictStats) {
     super()
   }
 
-  async getStats({
-    state,
-    districtType,
-    districtName,
-  }: StatsDTO): Promise<DistrictStats> {
-    const districtId = await this.districtService.findDistrictId({
-      state,
-      type: districtType,
-      name: districtName,
-    })
+  async getStats(dto: StatsDTO): Promise<DistrictStats> {
+    const districtId = dto.districtId
+      ? dto.districtId
+      : await this.districtService.findDistrictId({
+          state: dto.state!,
+          type: dto.districtType!,
+          name: dto.districtName!,
+        })
     const stats = await this.model.findUnique({ where: { districtId } })
 
     if (!stats) {

--- a/src/people/services/stats.service.ts
+++ b/src/people/services/stats.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, NotFoundException } from '@nestjs/common'
 import { DistrictStats } from '@prisma/client'
 import { createPrismaBase, MODELS } from 'src/prisma/util/prisma.util'
-import { StatsDTO } from '../people.schema'
+import { STATE_DISTRICT_TYPE, StatsDTO } from '../people.schema'
 import { DistrictService } from 'src/district/services/district.service'
 
 @Injectable()
@@ -14,11 +14,19 @@ export class StatsService extends createPrismaBase(MODELS.DistrictStats) {
     const { districtId: dtoDistrictId, state, districtType, districtName } = dto
     const districtId = dtoDistrictId
       ? dtoDistrictId
-      : await this.districtService.findDistrictId({
-          state: state!,
-          type: districtType!,
-          name: districtName!,
-        })
+      : await this.districtService.findDistrictId(
+          districtType && districtName
+            ? {
+                state: state!,
+                type: districtType,
+                name: districtName,
+              }
+            : {
+                state: state!,
+                type: STATE_DISTRICT_TYPE,
+                name: state!,
+              },
+        )
     const stats = await this.model.findUnique({ where: { districtId } })
 
     if (!stats) {

--- a/src/people/utils/resolveDistrict.utils.test.ts
+++ b/src/people/utils/resolveDistrict.utils.test.ts
@@ -1,0 +1,110 @@
+import { BadRequestException } from '@nestjs/common'
+import { describe, expect, it, vi } from 'vitest'
+import { STATE_DISTRICT_TYPE } from '../people.schema'
+import { resolveDistrict } from './resolveDistrict.utils'
+
+describe('resolveDistrict', () => {
+  it('resolves districtId-only query via district lookup', async () => {
+    const districtService = {
+      findDistrictById: vi.fn().mockResolvedValue({
+        id: '0e5bafca-93a9-86a5-2522-f373979720df',
+        type: 'City_Ward',
+        name: 'CHEYENNE CITY WARD 1',
+        state: 'WY',
+      }),
+      findDistrictId: vi.fn(),
+    }
+
+    const resolved = await resolveDistrict(districtService as never, {
+      districtId: '0e5bafca-93a9-86a5-2522-f373979720df',
+    })
+
+    expect(districtService.findDistrictById).toHaveBeenCalledWith(
+      '0e5bafca-93a9-86a5-2522-f373979720df',
+    )
+    expect(districtService.findDistrictId).not.toHaveBeenCalled()
+    expect(resolved).toEqual({
+      districtId: '0e5bafca-93a9-86a5-2522-f373979720df',
+      state: 'WY',
+      useVoterOnlyPath: false,
+      districtType: 'City_Ward',
+      districtName: 'CHEYENNE CITY WARD 1',
+    })
+  })
+
+  it('marks districtId-only state district as voter-only path', async () => {
+    const districtService = {
+      findDistrictById: vi.fn().mockResolvedValue({
+        id: 'district-wy',
+        type: STATE_DISTRICT_TYPE,
+        name: 'WY',
+        state: 'WY',
+      }),
+      findDistrictId: vi.fn(),
+    }
+
+    const resolved = await resolveDistrict(districtService as never, {
+      districtId: 'district-wy',
+    })
+
+    expect(resolved.useVoterOnlyPath).toBe(true)
+    expect(resolved.state).toBe('WY')
+  })
+
+  it('resolves state + districtType + districtName via district id lookup', async () => {
+    const districtService = {
+      findDistrictById: vi.fn(),
+      findDistrictId: vi.fn().mockResolvedValue('district-lookup-id'),
+    }
+
+    const resolved = await resolveDistrict(districtService as never, {
+      state: 'WY',
+      districtType: 'City_Ward',
+      districtName: 'CHEYENNE CITY WARD 1',
+    })
+
+    expect(districtService.findDistrictId).toHaveBeenCalledWith({
+      state: 'WY',
+      type: 'City_Ward',
+      name: 'CHEYENNE CITY WARD 1',
+    })
+    expect(districtService.findDistrictById).not.toHaveBeenCalled()
+    expect(resolved).toEqual({
+      districtId: 'district-lookup-id',
+      state: 'WY',
+      useVoterOnlyPath: false,
+      districtType: 'City_Ward',
+      districtName: 'CHEYENNE CITY WARD 1',
+    })
+  })
+
+  it('uses voter-only path for state-only queries', async () => {
+    const districtService = {
+      findDistrictById: vi.fn(),
+      findDistrictId: vi.fn(),
+    }
+
+    const resolved = await resolveDistrict(districtService as never, {
+      state: 'WY',
+    })
+
+    expect(resolved).toEqual({
+      districtId: null,
+      state: 'WY',
+      useVoterOnlyPath: true,
+    })
+    expect(districtService.findDistrictId).not.toHaveBeenCalled()
+    expect(districtService.findDistrictById).not.toHaveBeenCalled()
+  })
+
+  it('throws for missing district and missing state', async () => {
+    const districtService = {
+      findDistrictById: vi.fn(),
+      findDistrictId: vi.fn(),
+    }
+
+    await expect(resolveDistrict(districtService as never, {})).rejects.toThrow(
+      BadRequestException,
+    )
+  })
+})

--- a/src/people/utils/resolveDistrict.utils.ts
+++ b/src/people/utils/resolveDistrict.utils.ts
@@ -1,0 +1,57 @@
+import { DistrictService } from 'src/district/services/district.service'
+import { STATE_DISTRICT_TYPE } from '../people.schema'
+
+export interface ResolveDistrictParams {
+  state?: string
+  districtId?: string
+  districtType?: string
+  districtName?: string
+}
+
+export interface ResolvedDistrict {
+  districtId: string | null
+  state: string
+  useVoterOnlyPath: boolean
+  districtType?: string
+  districtName?: string
+}
+
+export async function resolveDistrict(
+  districtService: DistrictService,
+  params: ResolveDistrictParams,
+): Promise<ResolvedDistrict> {
+  const { state, districtId, districtType, districtName } = params
+  if (districtId && !districtType && !districtName) {
+    const district = await districtService.findDistrictById(districtId)
+    const useVoterOnlyPath =
+      district.type === STATE_DISTRICT_TYPE && district.name === district.state
+    return {
+      districtId: district.id,
+      state: district.state,
+      useVoterOnlyPath,
+      districtType: district.type,
+      districtName: district.name,
+    }
+  }
+  if (state && districtType && districtName) {
+    const resolvedId = await districtService.findDistrictId({
+      state,
+      type: districtType,
+      name: districtName,
+    })
+    const useVoterOnlyPath =
+      districtType === STATE_DISTRICT_TYPE && districtName === state
+    return {
+      districtId: resolvedId,
+      state,
+      useVoterOnlyPath,
+      districtType,
+      districtName,
+    }
+  }
+  return {
+    districtId: null,
+    state: state ?? '',
+    useVoterOnlyPath: true,
+  }
+}

--- a/src/people/utils/resolveDistrict.utils.ts
+++ b/src/people/utils/resolveDistrict.utils.ts
@@ -1,3 +1,4 @@
+import { BadRequestException } from '@nestjs/common'
 import { DistrictService } from 'src/district/services/district.service'
 import { STATE_DISTRICT_TYPE } from '../people.schema'
 
@@ -50,9 +51,15 @@ export async function resolveDistrict(
       districtName,
     }
   } else {
+    const stateOnlyState = state ?? ''
+    if (!stateOnlyState) {
+      throw new BadRequestException(
+        'state is required when district is not specified by districtId or by state+districtType+districtName',
+      )
+    }
     resolved = {
       districtId: null,
-      state: state ?? '',
+      state: stateOnlyState,
       useVoterOnlyPath: true,
     }
   }

--- a/src/people/utils/resolveDistrict.utils.ts
+++ b/src/people/utils/resolveDistrict.utils.ts
@@ -25,24 +25,25 @@ export async function resolveDistrict(
   const byDistrictId = !!districtId && !districtType && !districtName
   const byTypeName = !!state && !!districtType && !!districtName
 
-  let resolved: ResolvedDistrict
   if (byDistrictId) {
     const district = await districtService.findDistrictById(districtId!)
     const { id, type, name, state: districtState } = district
-    resolved = {
+    return {
       districtId: id,
       state: districtState,
       useVoterOnlyPath: type === STATE_DISTRICT_TYPE && name === districtState,
       districtType: type,
       districtName: name,
     }
-  } else if (byTypeName) {
+  }
+
+  if (byTypeName) {
     const resolvedId = await districtService.findDistrictId({
       state: state!,
       type: districtType!,
       name: districtName!,
     })
-    resolved = {
+    return {
       districtId: resolvedId,
       state: state!,
       useVoterOnlyPath:
@@ -50,18 +51,18 @@ export async function resolveDistrict(
       districtType,
       districtName,
     }
-  } else {
-    const stateOnlyState = state ?? ''
-    if (!stateOnlyState) {
-      throw new BadRequestException(
-        'state is required when district is not specified by districtId or by state+districtType+districtName',
-      )
-    }
-    resolved = {
-      districtId: null,
-      state: stateOnlyState,
-      useVoterOnlyPath: true,
-    }
   }
-  return resolved
+
+  const stateOnlyState = state ?? ''
+  if (!stateOnlyState) {
+    throw new BadRequestException(
+      'state is required when district is not specified by districtId or by state+districtType+districtName',
+    )
+  }
+
+  return {
+    districtId: null,
+    state: stateOnlyState,
+    useVoterOnlyPath: true,
+  }
 }


### PR DESCRIPTION
# Why

- Standardize district query inputs across people endpoints.
- Add support for districtId-only queries.
- Fix bugs found during test work (CSV field swap, count shortcut condition, sampling pool math).
- Reduce duplicated district/sampling logic and improve maintainability.
# Approach

- Added a shared resolver: resolveDistrict.
- Updated schemas to enforce one contract:
   - districtId only, or
   - state + districtType + districtName, or
   - state only.
- Refactored services (people, sample, stats) to use resolved district context.
- Added unit tests for schema + resolver + affected services.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core query/sampling paths and raw SQL construction, so regressions could impact result correctness and performance, though changes are well-covered by new unit tests.
> 
> **Overview**
> Adds a consistent district query contract across people endpoints: requests can now use **`districtId` only**, **`state + districtType + districtName`**, or **`state` only** (normalized to a statewide district), enforced in updated Zod schemas.
> 
> Introduces `resolveDistrict` to centralize district resolution and refactors `PeopleService`, `SampleService`, and `StatsService` to use it, including a new `DistrictService.findDistrictById`. This enables voter-only state queries (bypassing district joins) and supports `districtId`-direct stats lookups.
> 
> Fixes several issues discovered during testing: swaps CSV `electionLocation`/`electionType` assignments, corrects the “fast count” shortcut condition for empty filters, and fixes sampling pool/exclude math while adding a state-only sampling mode and more flexible anti-join handling. Adds Vitest unit tests covering schemas, resolver behavior, and updated service paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f88bac7bb7f3fe6bca2a7922e7339a7e108b6c8c. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->