### PR TITLE
disable newrelic log decoration

### DIFF
--- a/newrelic.js
+++ b/newrelic.js
@@ -17,7 +17,7 @@ if (!process.env.NEW_RELIC_APP_NAME || !process.env.NEW_RELIC_LICENSE_KEY) {
       enabled: true,
       forwarding: { enabled: false },
       metrics: { enabled: true },
-      local_decorating: { enabled: true },
+      local_decorating: { enabled: false },
     },
     error_collector: {
       enabled: true,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk configuration change that only affects how New Relic decorates local application logs; no business logic or data handling changes.
> 
> **Overview**
> Disables New Relic *local log decorating* by setting `application_logging.local_decorating.enabled` to `false` in `newrelic.js`, preventing New Relic from modifying/decorating local log output while leaving other New Relic instrumentation unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7d6d89e59d5fb6be9456e56acde0e7f049a84493. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->