### PR TITLE
Prod <- Dev

### DIFF
--- a/deploy/components/service.ts
+++ b/deploy/components/service.ts
@@ -54,251 +54,170 @@ export const createService = ({
   const select = <T>(values: Record<'dev' | 'prod', T>): T =>
     values[environment]
 
-  const cluster = new aws.ecs.Cluster(
-    'ecsCluster',
-    {
-      name: `people-api-${stage}-fargateCluster`,
-      settings: [{ name: 'containerInsights', value: 'enabled' }],
-    },
-    {
-      import: select({
-        dev: 'people-api-develop-fargateCluster',
-        prod: 'people-api-master-fargateCluster',
-      }),
-    },
-  )
+  const cluster = new aws.ecs.Cluster('ecsCluster', {
+    name: `people-api-${stage}-fargateCluster`,
+    settings: [{ name: 'containerInsights', value: 'enabled' }],
+  })
 
-  const albSecurityGroup = new aws.ec2.SecurityGroup(
-    'albSecurityGroup',
-    {
-      name: select({
-        dev: 'people-api-developLoadBalancerSecurityGroup-6afdb6d',
-        prod: 'people-api-masterLoadBalancerSecurityGroup-8f883e6',
-      }),
-      description: 'Managed by SST',
-      vpcId,
-      ingress: [
-        {
-          protocol: 'tcp',
-          fromPort: 80,
-          toPort: 80,
-          cidrBlocks: ['0.0.0.0/0'],
-          description: 'HTTP',
-        },
-        {
-          protocol: 'tcp',
-          fromPort: 443,
-          toPort: 443,
-          cidrBlocks: ['0.0.0.0/0'],
-          description: 'HTTPS',
-        },
-      ],
-      egress: [
-        {
-          protocol: '-1',
-          fromPort: 0,
-          toPort: 0,
-          cidrBlocks: ['0.0.0.0/0'],
-        },
-      ],
-    },
-    {
-      import: select({
-        dev: 'sg-050650a00b8b667ab',
-        prod: 'sg-0720011027aec3846',
-      }),
-    },
-  )
-
-  const loadBalancer = new aws.lb.LoadBalancer(
-    'loadBalancer',
-    {
-      name: select({
-        dev: 'peopleapidevelo-bcdrzucd',
-        prod: 'peopleapimaster-oxtdvruz',
-      }),
-      internal: false,
-      loadBalancerType: 'application',
-      securityGroups: [albSecurityGroup.id],
-      subnets: publicSubnetIds,
-      enableCrossZoneLoadBalancing: true,
-      idleTimeout: 120,
-    },
-    {
-      import: select({
-        dev: 'arn:aws:elasticloadbalancing:us-west-2:333022194791:loadbalancer/app/peopleapidevelo-bcdrzucd/90272295bd5fd3c8',
-        prod: 'arn:aws:elasticloadbalancing:us-west-2:333022194791:loadbalancer/app/peopleapimaster-oxtdvruz/3b8abd89d4fea654',
-      }),
-    },
-  )
-
-  const targetGroup = new aws.lb.TargetGroup(
-    'targetGroup',
-    {
-      name: select({
-        dev: 'HTTP20250909212256905800000002',
-        prod: 'HTTP20250910190439806700000002',
-      }),
-      port: 80,
-      protocol: 'HTTP',
-      targetType: 'ip',
-      vpcId,
-      deregistrationDelay: 300,
-      healthCheck: {
-        path: '/v1/health',
-        interval: 30,
-        timeout: 10,
-        healthyThreshold: 2,
-        unhealthyThreshold: 10,
-        matcher: '200',
+  const albSecurityGroup = new aws.ec2.SecurityGroup('albSecurityGroup', {
+    name: select({
+      dev: 'people-api-developLoadBalancerSecurityGroup-6afdb6d',
+      prod: 'people-api-masterLoadBalancerSecurityGroup-8f883e6',
+    }),
+    description: 'Managed by SST',
+    vpcId,
+    ingress: [
+      {
+        protocol: 'tcp',
+        fromPort: 80,
+        toPort: 80,
+        cidrBlocks: ['0.0.0.0/0'],
+        description: 'HTTP',
       },
-    },
-    {
-      import: select({
-        dev: 'arn:aws:elasticloadbalancing:us-west-2:333022194791:targetgroup/HTTP20250909212256905800000002/58a5c2d6260f072d',
-        prod: 'arn:aws:elasticloadbalancing:us-west-2:333022194791:targetgroup/HTTP20250910190439806700000002/5dae75318be39fc8',
-      }),
-    },
-  )
+      {
+        protocol: 'tcp',
+        fromPort: 443,
+        toPort: 443,
+        cidrBlocks: ['0.0.0.0/0'],
+        description: 'HTTPS',
+      },
+    ],
+    egress: [
+      {
+        protocol: '-1',
+        fromPort: 0,
+        toPort: 0,
+        cidrBlocks: ['0.0.0.0/0'],
+      },
+    ],
+  })
 
-  new aws.lb.Listener(
-    'httpListener',
-    {
-      loadBalancerArn: loadBalancer.arn,
-      port: 80,
-      protocol: 'HTTP',
-      defaultActions: [{ type: 'forward', targetGroupArn: targetGroup.arn }],
-    },
-    {
-      import: select({
-        dev: 'arn:aws:elasticloadbalancing:us-west-2:333022194791:listener/app/peopleapidevelo-bcdrzucd/90272295bd5fd3c8/c4897cb487a06749',
-        prod: 'arn:aws:elasticloadbalancing:us-west-2:333022194791:listener/app/peopleapimaster-oxtdvruz/3b8abd89d4fea654/46167b949c8e9be3',
-      }),
-    },
-  )
+  const loadBalancer = new aws.lb.LoadBalancer('loadBalancer', {
+    name: select({
+      dev: 'peopleapidevelo-bcdrzucd',
+      prod: 'peopleapimaster-oxtdvruz',
+    }),
+    internal: false,
+    loadBalancerType: 'application',
+    securityGroups: [albSecurityGroup.id],
+    subnets: publicSubnetIds,
+    enableCrossZoneLoadBalancing: true,
+    idleTimeout: 120,
+  })
 
-  new aws.lb.Listener(
-    'httpsListener',
-    {
-      loadBalancerArn: loadBalancer.arn,
-      port: 443,
-      protocol: 'HTTPS',
-      certificateArn,
-      sslPolicy: 'ELBSecurityPolicy-2016-08',
-      defaultActions: [{ type: 'forward', targetGroupArn: targetGroup.arn }],
+  const targetGroup = new aws.lb.TargetGroup('targetGroup', {
+    name: select({
+      dev: 'HTTP20250909212256905800000002',
+      prod: 'HTTP20250910190439806700000002',
+    }),
+    port: 80,
+    protocol: 'HTTP',
+    targetType: 'ip',
+    vpcId,
+    deregistrationDelay: 300,
+    healthCheck: {
+      path: '/v1/health',
+      interval: 30,
+      timeout: 10,
+      healthyThreshold: 2,
+      unhealthyThreshold: 10,
+      matcher: '200',
     },
-    {
-      import: select({
-        dev: 'arn:aws:elasticloadbalancing:us-west-2:333022194791:listener/app/peopleapidevelo-bcdrzucd/90272295bd5fd3c8/e68b0123d8954dfa',
-        prod: 'arn:aws:elasticloadbalancing:us-west-2:333022194791:listener/app/peopleapimaster-oxtdvruz/3b8abd89d4fea654/8f2db0616a903763',
-      }),
-    },
-  )
+  })
 
-  const logGroup = new aws.cloudwatch.LogGroup(
-    'logGroup',
-    {
-      name: select({
-        dev: '/sst/cluster/people-api-develop-fargateCluster/people-api-develop-peopleapidevelop-mvorhfaf/people-api-develop',
-        prod: '/sst/cluster/people-api-master-fargateCluster/people-api-master-peopleapimaster-hckafcee/people-api-master',
-      }),
-      retentionInDays: isProd ? 60 : 30,
-    },
-    {
-      import: select({
-        dev: '/sst/cluster/people-api-develop-fargateCluster/people-api-develop-peopleapidevelop-mvorhfaf/people-api-develop',
-        prod: '/sst/cluster/people-api-master-fargateCluster/people-api-master-peopleapimaster-hckafcee/people-api-master',
-      }),
-    },
-  )
+  new aws.lb.Listener('httpListener', {
+    loadBalancerArn: loadBalancer.arn,
+    port: 80,
+    protocol: 'HTTP',
+    defaultActions: [{ type: 'forward', targetGroupArn: targetGroup.arn }],
+  })
 
-  const executionRole = new aws.iam.Role(
-    'executionRole',
-    {
-      name: select({
-        dev: 'people-api-develop-peopleapidevelopExecutionRole-bdcobows',
-        prod: 'people-api-master-peopleapimasterExecutionRole-zomwmssh',
-      }),
-      assumeRolePolicy: JSON.stringify({
-        Version: '2012-10-17',
-        Statement: [
-          {
-            Action: 'sts:AssumeRole',
-            Effect: 'Allow',
-            Principal: {
-              Service: 'ecs-tasks.amazonaws.com',
-            },
-          },
-        ],
-      }),
-      managedPolicyArns: [
-        'arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy',
-      ],
-      inlinePolicies: [
+  new aws.lb.Listener('httpsListener', {
+    loadBalancerArn: loadBalancer.arn,
+    port: 443,
+    protocol: 'HTTPS',
+    certificateArn,
+    sslPolicy: 'ELBSecurityPolicy-2016-08',
+    defaultActions: [{ type: 'forward', targetGroupArn: targetGroup.arn }],
+  })
+
+  const logGroup = new aws.cloudwatch.LogGroup('logGroup', {
+    name: select({
+      dev: '/sst/cluster/people-api-develop-fargateCluster/people-api-develop-peopleapidevelop-mvorhfaf/people-api-develop',
+      prod: '/sst/cluster/people-api-master-fargateCluster/people-api-master-peopleapimaster-hckafcee/people-api-master',
+    }),
+    retentionInDays: isProd ? 60 : 30,
+  })
+
+  const executionRole = new aws.iam.Role('executionRole', {
+    name: select({
+      dev: 'people-api-develop-peopleapidevelopExecutionRole-bdcobows',
+      prod: 'people-api-master-peopleapimasterExecutionRole-zomwmssh',
+    }),
+    assumeRolePolicy: JSON.stringify({
+      Version: '2012-10-17',
+      Statement: [
         {
-          name: 'inline',
-          policy: pulumi.jsonStringify({
-            Version: '2012-10-17',
-            Statement: [
-              {
-                Effect: 'Allow',
-                Action: [
-                  'ssm:GetParameters',
-                  'ssm:GetParameterHistory',
-                  'ssm:GetParameter',
-                  'secretsmanager:GetSecretValue',
-                ],
-                Resource: '*',
-              },
-            ],
-          }),
+          Action: 'sts:AssumeRole',
+          Effect: 'Allow',
+          Principal: {
+            Service: 'ecs-tasks.amazonaws.com',
+          },
         },
       ],
-    },
-    {
-      import: select({
-        dev: 'people-api-develop-peopleapidevelopExecutionRole-bdcobows',
-        prod: 'people-api-master-peopleapimasterExecutionRole-zomwmssh',
-      }),
-    },
-  )
-
-  const taskRole = new aws.iam.Role(
-    'taskRole',
-    {
-      name: select({
-        dev: 'people-api-develop-peopleapidevelopTaskRole-fhfkkshn',
-        prod: 'people-api-master-peopleapimasterTaskRole-kdcsvrdo',
-      }),
-      assumeRolePolicy: JSON.stringify({
-        Version: '2012-10-17',
-        Statement: [
-          {
-            Action: 'sts:AssumeRole',
-            Effect: 'Allow',
-            Principal: {
-              Service: 'ecs-tasks.amazonaws.com',
+    }),
+    managedPolicyArns: [
+      'arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy',
+    ],
+    inlinePolicies: [
+      {
+        name: 'inline',
+        policy: pulumi.jsonStringify({
+          Version: '2012-10-17',
+          Statement: [
+            {
+              Effect: 'Allow',
+              Action: [
+                'ssm:GetParameters',
+                'ssm:GetParameterHistory',
+                'ssm:GetParameter',
+                'secretsmanager:GetSecretValue',
+              ],
+              Resource: '*',
             },
-          },
-        ],
-      }),
-      inlinePolicies: [
+          ],
+        }),
+      },
+    ],
+  })
+
+  const taskRole = new aws.iam.Role('taskRole', {
+    name: select({
+      dev: 'people-api-develop-peopleapidevelopTaskRole-fhfkkshn',
+      prod: 'people-api-master-peopleapimasterTaskRole-kdcsvrdo',
+    }),
+    assumeRolePolicy: JSON.stringify({
+      Version: '2012-10-17',
+      Statement: [
         {
-          name: 'inline',
-          policy: pulumi.jsonStringify({
-            Version: '2012-10-17',
-            Statement: permissions,
-          }),
+          Action: 'sts:AssumeRole',
+          Effect: 'Allow',
+          Principal: {
+            Service: 'ecs-tasks.amazonaws.com',
+          },
         },
       ],
-    },
-    {
-      import: select({
-        dev: 'people-api-develop-peopleapidevelopTaskRole-fhfkkshn',
-        prod: 'people-api-master-peopleapimasterTaskRole-kdcsvrdo',
-      }),
-    },
-  )
+    }),
+    inlinePolicies: [
+      {
+        name: 'inline',
+        policy: pulumi.jsonStringify({
+          Version: '2012-10-17',
+          Statement: permissions,
+        }),
+      },
+    ],
+  })
 
   const cpu = isProd ? '1024' : '512'
   const memory = isProd ? '4096' : '2048'
@@ -359,85 +278,58 @@ export const createService = ({
     ),
   })
 
-  new aws.ecs.Service(
-    'ecsService',
-    {
-      name: serviceName,
-      cluster: cluster.arn,
-      taskDefinition: taskDefinition.arn,
-      desiredCount: isProd ? 2 : 1,
-      capacityProviderStrategies: [{ capacityProvider: 'FARGATE', weight: 1 }],
-      networkConfiguration: {
-        subnets: publicSubnetIds,
-        securityGroups: securityGroupIds,
-        assignPublicIp: true,
-      },
-      loadBalancers: [
-        {
-          targetGroupArn: targetGroup.arn,
-          containerName: serviceName,
-          containerPort: 80,
-        },
-      ],
-      healthCheckGracePeriodSeconds: 120,
-      deploymentCircuitBreaker: {
-        enable: true,
-        rollback: true,
-      },
-      enableExecuteCommand: true,
-      forceNewDeployment: true,
-      waitForSteadyState: true,
+  new aws.ecs.Service('ecsService', {
+    name: serviceName,
+    cluster: cluster.arn,
+    taskDefinition: taskDefinition.arn,
+    desiredCount: isProd ? 2 : 1,
+    capacityProviderStrategies: [{ capacityProvider: 'FARGATE', weight: 1 }],
+    networkConfiguration: {
+      subnets: publicSubnetIds,
+      securityGroups: securityGroupIds,
+      assignPublicIp: true,
     },
-    {
-      import: select({
-        dev: 'people-api-develop-fargateCluster/people-api-develop',
-        prod: 'people-api-master-fargateCluster/people-api-master',
-      }),
+    loadBalancers: [
+      {
+        targetGroupArn: targetGroup.arn,
+        containerName: serviceName,
+        containerPort: 80,
+      },
+    ],
+    healthCheckGracePeriodSeconds: 120,
+    deploymentCircuitBreaker: {
+      enable: true,
+      rollback: true,
     },
-  )
+    enableExecuteCommand: true,
+    forceNewDeployment: true,
+    waitForSteadyState: true,
+  })
 
-  new aws.route53.Record(
-    'dnsARecord',
-    {
-      zoneId: hostedZoneId,
-      name: domain,
-      type: 'A',
-      aliases: [
-        {
-          name: loadBalancer.dnsName,
-          zoneId: loadBalancer.zoneId,
-          evaluateTargetHealth: true,
-        },
-      ],
-    },
-    {
-      import: select({
-        dev: 'Z10392302OXMPNQLPO07K_people-api-dev.goodparty.org_A',
-        prod: 'Z10392302OXMPNQLPO07K_people-api.goodparty.org_A',
-      }),
-    },
-  )
-  new aws.route53.Record(
-    'dnsAAAARecord',
-    {
-      zoneId: hostedZoneId,
-      name: domain,
-      type: 'AAAA',
-      aliases: [
-        {
-          name: loadBalancer.dnsName,
-          zoneId: loadBalancer.zoneId,
-          evaluateTargetHealth: true,
-        },
-      ],
-    },
-    {
-      import: select({
-        dev: 'Z10392302OXMPNQLPO07K_people-api-dev.goodparty.org_AAAA',
-        prod: 'Z10392302OXMPNQLPO07K_people-api.goodparty.org_AAAA',
-      }),
-    },
-  )
+  new aws.route53.Record('dnsARecord', {
+    zoneId: hostedZoneId,
+    name: domain,
+    type: 'A',
+    aliases: [
+      {
+        name: loadBalancer.dnsName,
+        zoneId: loadBalancer.zoneId,
+        evaluateTargetHealth: true,
+      },
+    ],
+  })
+  new aws.route53.Record('dnsAAAARecord', {
+    zoneId: hostedZoneId,
+    name: domain,
+    type: 'AAAA',
+    aliases: [
+      {
+        name: loadBalancer.dnsName,
+        zoneId: loadBalancer.zoneId,
+        evaluateTargetHealth: true,
+      },
+    ],
+  })
 
   return {
     url: pulumi.interpolate`https://${domain}`,

--- a/src/people/services/sample.service.ts
+++ b/src/people/services/sample.service.ts
@@ -22,7 +22,7 @@ export class SampleService extends createPrismaBase(MODELS.Voter) {
   private static readonly BUCKET_COUNT = 3
   private static readonly MAX_HASH_DIVISOR = 10000
   private static readonly MIN_HASH_DIVISOR = 1
-  private static readonly MIN_POPULATION_MULTIPLIER = 1.5
+  private static readonly MIN_POPULATION_MULTIPLIER = 0.5
   private static readonly PRELIMIT_MULTIPLIER = 2
   private static readonly MAX_PRELIMIT = 20000
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Removes Pulumi `import` bindings for existing ECS/ALB/Route53 and RDS resources, which can cause resource replacement/duplication or deployment failures and potential downtime. Also changes sampling heuristics, which may alter query behavior and result sizes.
> 
> **Overview**
> **Pulumi deployment now creates infra resources instead of importing existing ones.** The `import` options were removed across `deploy/components/service.ts` (ECS cluster/service, ALB + listeners/target group, security group, log group, Route53 records, IAM roles) and `deploy/index.ts` (RDS subnet group/cluster/instances).
> 
> **Sampling behavior change:** `SampleService` lowers `MIN_POPULATION_MULTIPLIER` from `1.5` to `0.5`, which changes when bucketing is disabled during people sampling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7b693be5a8441eb161eb94ddbe2234d230a38f67. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->