### PR TITLE
fix deployment circuit breaker

### DIFF
--- a/deploy/components/service.ts
+++ b/deploy/components/service.ts
@@ -299,7 +299,7 @@ export const createService = ({
     healthCheckGracePeriodSeconds: 120,
     deploymentCircuitBreaker: {
       enable: true,
-      rollback: true,
+      rollback: false,
     },
     enableExecuteCommand: true,
     forceNewDeployment: true,


### PR DESCRIPTION
See https://github.com/thegoodparty/gp-api/pull/1230

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes ECS deployment behavior by disabling automatic rollback on circuit breaker trips, which can affect production recovery semantics and leave failed deployments in a degraded state until manually intervened.
> 
> **Overview**
> Adjusts the ECS service `deploymentCircuitBreaker` configuration to **stop automatically rolling back** when deployments fail (`rollback: true` → `rollback: false`).
> 
> This changes how failed deploys are handled during rollout (failure will trip the circuit breaker without reverting to the previous task set), impacting operational response during bad releases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 97a53cb0fe3943c3fc7d8a635a76252a684d13e8. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->