### PR TITLE
fix: use green schema for USState type cast in raw queries

### DIFF
--- a/src/people/services/people.service.ts
+++ b/src/people/services/people.service.ts
@@ -73,7 +73,7 @@ export class PeopleService extends createPrismaBase(MODELS.Voter) {
         : Prisma.empty
 
     const result = await this.client.$queryRaw<BaseDbPerson[]>(
-      Prisma.sql`${select} FROM "green"."Voter" v WHERE v."id" = ${id}::uuid AND v."State" = CAST(${state}::text AS "public"."USState") ${districtExistsClause}`,
+      Prisma.sql`${select} FROM "green"."Voter" v WHERE v."id" = ${id}::uuid AND v."State" = CAST(${state}::text AS "green"."USState") ${districtExistsClause}`,
     )
     if (!result.length) {
       if (districtId && !useVoterOnlyPath) {
@@ -250,11 +250,11 @@ export class PeopleService extends createPrismaBase(MODELS.Voter) {
 
     const parts: Prisma.Sql[] = []
     parts.push(
-      Prisma.sql`v."State" = CAST(${state}::text AS "public"."USState")`,
+      Prisma.sql`v."State" = CAST(${state}::text AS "green"."USState")`,
     )
     if (districtId) {
       parts.push(
-        Prisma.sql`dv."State" = CAST(${state}::text AS "public"."USState")`,
+        Prisma.sql`dv."State" = CAST(${state}::text AS "green"."USState")`,
       )
       parts.push(Prisma.sql`dv."district_id" = ${districtId}::uuid`)
       parts.push(Prisma.sql`dv."voter_id" IS NOT NULL`)


### PR DESCRIPTION
## Summary

- Raw SQL queries in `people.service.ts` were casting state values to `"public"."USState"`, but the `Voter` and `DistrictVoter` tables live in the `green` schema
- This type mismatch prevents PostgreSQL from using indexes on the `State` columns, forcing a full sequential scan on every `COUNT(*)` query
- The COUNT query was taking **~3,900–4,010ms** per request, making `POST /v1/people` consistently slow

**Root cause traces:**
- [people-api trace 595a027](https://goodparty.grafana.net/explore?schemaVersion=1&panes=%7B%22a%22%3A%7B%22datasource%22%3A%22grafanacloud-traces%22%2C%22queries%22%3A%5B%7B%22refId%22%3A%22A%22%2C%22query%22%3A%22595a027113c279a2fe7beb2c46afc22d%22%2C%22datasource%22%3A%7B%22type%22%3A%22tempo%22%2C%22uid%22%3A%22grafanacloud-traces%22%7D%7D%5D%7D%7D) — COUNT took 3905ms
- [people-api trace 918a8f4](https://goodparty.grafana.net/explore?schemaVersion=1&panes=%7B%22a%22%3A%7B%22datasource%22%3A%22grafanacloud-traces%22%2C%22queries%22%3A%5B%7B%22refId%22%3A%22A%22%2C%22query%22%3A%22918a8f470fc5e623671d37d083b93132%22%2C%22datasource%22%3A%7B%22type%22%3A%22tempo%22%2C%22uid%22%3A%22grafanacloud-traces%22%7D%7D%5D%7D%7D) — COUNT took 4010ms

**Fix:** Change all `CAST(... AS "public"."USState")` → `CAST(... AS "green"."USState")` in `rawBuildWhere` and `getById` (3 occurrences in `people.service.ts`).

## Test plan

- [ ] Deploy to QA and run `POST /v1/people` with a district filter — confirm p95 latency drops significantly
- [ ] Verify `GET /v1/contacts` in gp-api also recovers (it was blocked on this call)
- [ ] Check that state filtering still returns correct results (no regression in data)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches raw SQL used by `GET /people` and count queries; while change is small, it can affect query results and performance if the enum/schema differs across environments.
> 
> **Overview**
> Updates `PeopleService` raw SQL to cast state values to `"green"."USState"` (instead of `"public"."USState"`) in both `findPerson` and `rawBuildWhere`.
> 
> This aligns the cast type with the `green`-schema tables (`Voter`/`DistrictVoter`), avoiding type mismatches that can prevent index usage on `State`-filtered queries.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5af6dad95ecfd0a6070b6ba8b4f1e04d8c6c6668. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->