### PR TITLE
feat: split count query into POST /v1/people/count endpoint

### DIFF
--- a/src/people/people.controller.ts
+++ b/src/people/people.controller.ts
@@ -1,5 +1,6 @@
 import { Controller, Get, Post, Param, Query, Res, Body } from '@nestjs/common'
 import {
+  CountPeopleDTO,
   DownloadPeopleDTO,
   GetPersonParamsDTO,
   GetPersonQueryDTO,
@@ -21,6 +22,11 @@ export class PeopleController {
   @Post()
   listPeople(@Body() filterDto: ListPeopleDTO) {
     return this.peopleService.findPeople(filterDto)
+  }
+
+  @Post('count')
+  countPeople(@Body() filterDto: CountPeopleDTO) {
+    return this.peopleService.countPeople(filterDto)
   }
 
   @Post('download')

--- a/src/people/people.schema.ts
+++ b/src/people/people.schema.ts
@@ -64,6 +64,15 @@ export const listPeopleSchema = withDistrictInput({
 
 export class ListPeopleDTO extends createZodDto(listPeopleSchema) {}
 
+export const countPeopleSchema = withDistrictInput({
+  filters: filtersSchema,
+  search: z.string().optional(),
+  resultsPerPage: z.coerce.number().optional().default(50),
+  page: z.coerce.number().optional().default(1),
+})
+
+export class CountPeopleDTO extends createZodDto(countPeopleSchema) {}
+
 export const downloadPeopleSchema = withDistrictInput({
   electionLocation: z.string().optional(),
   electionType: z.string().optional(),

--- a/src/people/services/people.service.ts
+++ b/src/people/services/people.service.ts
@@ -1,5 +1,6 @@
 import { Prisma } from '@prisma/client'
 import {
+  CountPeopleDTO,
   DownloadPeopleDTO,
   GetPersonQueryDTO,
   ListPeopleDTO,
@@ -90,31 +91,47 @@ export class PeopleService extends createPrismaBase(MODELS.Voter) {
     const { filters, search, resultsPerPage, page } = dto
     const effectiveDistrictId = useVoterOnlyPath ? null : districtId
 
-    // TODO: This executes count and data query in parallel
-    // for latency, but the data query uses the requested page offset while
-    // currentPage is clamped from totalResults below. If requested page is out
-    // of bounds, pagination metadata and returned rows can diverge.
-    const [totalResults, people] = await Promise.all([
-      this.rawCountForDistrict({
-        state,
+    const fetchSize = resultsPerPage + 1
+    const rows = await this.client.$queryRaw<Array<BaseDbPerson>>(
+      this.buildRawPeopleQuery({
         districtId: effectiveDistrictId,
-        filters,
-        search,
-      }),
-      this.client.$queryRaw<Array<BaseDbPerson>>(
-        this.buildRawPeopleQuery({
+        whereClause: this.rawBuildWhere({
+          state,
           districtId: effectiveDistrictId,
-          whereClause: this.rawBuildWhere({
-            state,
-            districtId: effectiveDistrictId,
-            filters,
-            search,
-          }),
-          take: resultsPerPage,
-          skip: (page - 1) * resultsPerPage,
+          filters,
+          search,
         }),
-      ),
-    ])
+        take: fetchSize,
+        skip: (page - 1) * resultsPerPage,
+      }),
+    )
+
+    const hasNextPage = rows.length > resultsPerPage
+    const people = hasNextPage ? rows.slice(0, resultsPerPage) : rows
+
+    return {
+      pagination: {
+        currentPage: page,
+        pageSize: resultsPerPage,
+        hasNextPage,
+        hasPreviousPage: page > 1,
+      },
+      people: people.map(transformToPersonOutput),
+    }
+  }
+
+  async countPeople(dto: CountPeopleDTO) {
+    const resolved = await resolveDistrict(this.districtService, dto)
+    const { state, useVoterOnlyPath, districtId } = resolved
+    const { filters, search, resultsPerPage, page } = dto
+    const effectiveDistrictId = useVoterOnlyPath ? null : districtId
+
+    const totalResults = await this.rawCountForDistrict({
+      state,
+      districtId: effectiveDistrictId,
+      filters,
+      search,
+    })
 
     const totalPages = Math.max(1, Math.ceil(totalResults / resultsPerPage))
     const currentPage = Math.min(Math.max(1, page), totalPages)
@@ -128,7 +145,6 @@ export class PeopleService extends createPrismaBase(MODELS.Voter) {
         hasNextPage: currentPage < totalPages,
         hasPreviousPage: currentPage > 1,
       },
-      people: people.map(transformToPersonOutput),
     }
   }
 


### PR DESCRIPTION
## Summary
- Extracts the COUNT query from `POST /v1/people` into a new dedicated `POST /v1/people/count` endpoint
- The list endpoint now returns pagination without `totalResults`/`totalPages`, using a fetch-one-extra trick to determine `hasNextPage`
- The count endpoint returns full pagination including `totalResults` and `totalPages`

## Motivation
The COUNT query on the `green.Voter` table was taking 1–3 seconds on every list request, blocking the entire response. Splitting it into a separate endpoint allows the list to return immediately while the total count loads asynchronously.

🤖 Generated with Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `POST /v1/people` response shape and pagination behavior and introduces a new endpoint, which may require coordinated client updates and could affect paging edge cases.
> 
> **Overview**
> Adds a new `POST /people/count` endpoint (with `CountPeopleDTO`) that runs the expensive COUNT query and returns full pagination metadata (`totalResults`/`totalPages`).
> 
> Updates `POST /people` to stop executing COUNT on every request; it now fetches `resultsPerPage + 1` rows to compute `hasNextPage` and returns only lightweight pagination fields plus the page of people.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c272f278a765776c02459cfcefe760c69ba3ff49. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->