### PR TITLE
ENG-6987: just use district

### DIFF
--- a/api-examples.http
+++ b/api-examples.http
@@ -1,37 +1,29 @@
-### List people from a district
-GET http://localhost:3002/v1/people?state=WY&districtType=Unified_School_District&districtName=LINCOLN%20CNTY%20SD%202%20(EST.)
+### List people from a district (replace DISTRICT_ID with a real UUID)
+POST http://localhost:3002/v1/people
+Content-Type: application/json
+
+{"districtId": "REPLACE_WITH_DISTRICT_ID", "filters": {}}
 
 ### List people with language and voter status filters
-GET http://localhost:3002/v1/people?state=WY&districtType=Unified_School_District&districtName=LINCOLN%20CNTY%20SD%202%20(EST.)&resultsPerPage=50&page=1&filter[languageCode][in][]=EN&filter[languageCode][in][]=ES&filter[voterStatus][eq]=Active
+POST http://localhost:3002/v1/people
+Content-Type: application/json
 
-### List people where educationOfPerson is non-null
-GET http://localhost:3002/v1/people?state=WY&districtType=Unified_School_District&districtName=LINCOLN%20CNTY%20SD%202%20(EST.)&filter[educationOfPerson][is]=not_null
-
-### List people with registeredVoter true or false (boolean IN)
-GET http://localhost:3002/v1/people?state=WY&districtType=Unified_School_District&districtName=LINCOLN%20CNTY%20SD%202%20(EST.)&filter[registeredVoter][in][]=true&filter[registeredVoter][in][]=false
+{"districtId": "REPLACE_WITH_DISTRICT_ID", "filters": {"languageCode": {"in": ["EN", "ES"]}, "voterStatus": {"eq": "Active"}}, "resultsPerPage": 50, "page": 1}
 
 ### Download CSV with veteranStatus IN and presenceOfChildren is null
-GET http://localhost:3002/v1/people/download?state=WY&districtType=Unified_School_District&districtName=LINCOLN%20CNTY%20SD%202%20(EST.)&filter[veteranStatus][in][]=Yes&filter[veteranStatus][in][]=No&filter[presenceOfChildren][is]=null
+POST http://localhost:3002/v1/people/download
+Content-Type: application/json
 
-### Stats: basic defaults (age, homeowner, income, education, family)
-GET http://localhost:3002/v1/people/stats?state=WY&districtType=Unified_School_District&districtName=LINCOLN%20CNTY%20SD%202%20(EST.)
+{"districtId": "REPLACE_WITH_DISTRICT_ID", "filters": {"veteranStatus": {"in": ["Yes", "No"]}, "presenceOfChildren": {"is": "null"}}}
 
-### Stats: add facets (gender and partiesDescription) and limit topN
-GET http://localhost:3002/v1/people/stats?state=WY&districtType=Unified_School_District&districtName=LINCOLN%20CNTY%20SD%202%20(EST.)&categories[]=gender&categories[]=partiesDescription&topN=5
+### Stats for a district
+GET http://localhost:3002/v1/people/stats?districtId=REPLACE_WITH_DISTRICT_ID
 
-### Stats: custom numeric buckets for age and income (uses Estimated_Income_Amount_Int)
-# Note: numericBuckets uses inclusive ranges [min,max]
-GET http://localhost:3002/v1/people/stats?state=WY&districtType=Unified_School_District&districtName=LINCOLN%20CNTY%20SD%202%20(EST.)&numericBuckets[ageInt][]=18,25&numericBuckets[ageInt][]=26,35&numericBuckets[ageInt][]=36,49&numericBuckets[ageInt][]=50,200&numericBuckets[estimatedIncomeAmountInt][]=0,40000&numericBuckets[estimatedIncomeAmountInt][]=40001,80000&numericBuckets[estimatedIncomeAmountInt][]=80001,120000&numericBuckets[estimatedIncomeAmountInt][]=120001,1000000000
+### Sample from a district
+POST http://localhost:3002/v1/people/sample
+Content-Type: application/json
 
-### Stats: with demographic filter (registeredVoter true, veteranStatus in Yes/No)
-GET http://localhost:3002/v1/people/stats?state=WY&districtType=Unified_School_District&districtName=LINCOLN%20CNTY%20SD%202%20(EST.)&filter[registeredVoter][eq]=true&filter[veteranStatus][in][]=Yes&filter[veteranStatus][in][]=No
+{"districtId": "REPLACE_WITH_DISTRICT_ID", "size": 500}
 
-### Search voters by phone
-GET http://localhost:3002/v1/people/search?phone=307-248-0741&state=WY
-
-### Search voters by name
-GET http://localhost:3002/v1/people/search?name=David%20Hokanson&state=WY
-
-### Search voters by first and last name with district
-GET http://localhost:3002/v1/people/search?firstName=David&lastName=Hokanson&state=WY&districtType=Unified_School_District&districtName=LINCOLN%20CNTY%20SD%202%20(EST.)&page=1&resultsPerPage=25
-
+### Get single person
+GET http://localhost:3002/v1/people/REPLACE_WITH_PERSON_ID?districtId=REPLACE_WITH_DISTRICT_ID

--- a/perf/mixed.ts
+++ b/perf/mixed.ts
@@ -3,6 +3,15 @@ import { Trend, Rate } from 'k6/metrics'
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { buildUrl, buildHeaders } = require('./common.js')
 
+const DISTRICT_PEOPLE_SMALL =
+  __ENV.DISTRICT_PEOPLE_SMALL || '22f911d1-8262-ec9d-257f-7bb0ccb563c1'
+const DISTRICT_PEOPLE_LARGE =
+  __ENV.DISTRICT_PEOPLE_LARGE || '7e38d7a0-bb29-99bc-74c6-cadd54f1afc7'
+const DISTRICT_STATS_LARGE =
+  __ENV.DISTRICT_STATS_LARGE || '47b7b5fb-5edf-70dc-5448-ef5f545a4793'
+const DISTRICT_SAMPLE_SMALL =
+  __ENV.DISTRICT_SAMPLE_SMALL || 'd79c532c-ee5f-cf01-758f-bd62d4fca41c'
+
 export const options = {
   scenarios: {
     mixed: {
@@ -110,9 +119,7 @@ export function runMixed() {
     url = buildUrl('/people')
     method = 'POST'
     body = JSON.stringify({
-      state: 'WY',
-      districtType: 'County_Commissioner_District',
-      districtName: 'SWEETWATER CNTY-ROCK SPRINGS NORTH CCD (EST.)',
+      districtId: DISTRICT_PEOPLE_SMALL,
       filters: {
         gender: { is: 'not_null' },
         educationLevel: { is: 'not_null' },
@@ -126,9 +133,7 @@ export function runMixed() {
     url = buildUrl('/people')
     method = 'POST'
     body = JSON.stringify({
-      state: 'TX',
-      districtType: 'City',
-      districtName: 'DALLAS CITY (EST.)',
+      districtId: DISTRICT_PEOPLE_LARGE,
       filters: {
         gender: { is: 'not_null' },
         educationLevel: { is: 'not_null' },
@@ -140,18 +145,14 @@ export function runMixed() {
     }
   } else if (cohort === 'stats_large') {
     url = buildUrl('/people/stats', {
-      state: 'WI',
-      districtType: 'City',
-      districtName: 'MILWAUKEE CITY',
+      districtId: DISTRICT_STATS_LARGE,
     })
     headers = buildHeaders('perf:mixed stats large')
   } else {
     url = buildUrl('/people/sample')
     method = 'POST'
     body = JSON.stringify({
-      state: 'FL',
-      districtType: 'City',
-      districtName: 'NICEVILLE CITY (EST.)',
+      districtId: DISTRICT_SAMPLE_SMALL,
       size: 1000,
     })
     headers = {

--- a/perf/people-get.ts
+++ b/perf/people-get.ts
@@ -2,6 +2,15 @@ import http from 'k6/http'
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { buildUrl, recordMetrics, buildHeaders } = require('./common.js')
 
+const DISTRICT_SMALL =
+  __ENV.DISTRICT_SMALL || '22f911d1-8262-ec9d-257f-7bb0ccb563c1'
+const DISTRICT_LARGE =
+  __ENV.DISTRICT_LARGE || '7e38d7a0-bb29-99bc-74c6-cadd54f1afc7'
+const DISTRICT_SMALL_FILTERS =
+  __ENV.DISTRICT_SMALL_FILTERS || '0d04f04f-ace2-e4e4-c056-de86c8f4f377'
+const DISTRICT_LARGE_FILTERS =
+  __ENV.DISTRICT_LARGE_FILTERS || 'fed71a30-f074-37bf-bb9d-8e2acda1bd1c'
+
 const baseScenarios = {
   small: { executor: 'constant-vus', vus: 3, duration: '30s', exec: 'small' },
   large: {
@@ -55,9 +64,7 @@ export const options =
 export function small() {
   const url = buildUrl('/people')
   const body = JSON.stringify({
-    state: 'WY',
-    districtType: 'County_Commissioner_District',
-    districtName: 'SWEETWATER CNTY-ROCK SPRINGS NORTH CCD (EST.)',
+    districtId: DISTRICT_SMALL,
     filters: {
       gender: { is: 'not_null' },
       educationLevel: { is: 'not_null' },
@@ -75,9 +82,7 @@ export function small() {
 export function large() {
   const url = buildUrl('/people')
   const body = JSON.stringify({
-    state: 'TX',
-    districtType: 'City',
-    districtName: 'DALLAS CITY (EST.)',
+    districtId: DISTRICT_LARGE,
     filters: {
       gender: { is: 'not_null' },
       educationLevel: { is: 'not_null' },
@@ -95,9 +100,7 @@ export function large() {
 export function small_full_filters() {
   const url = buildUrl('/people')
   const body = JSON.stringify({
-    state: 'NH',
-    districtType: 'City',
-    districtName: 'CONCORD CITY',
+    districtId: DISTRICT_SMALL_FILTERS,
     filters: {
       hasCellPhone: true,
       hasLandline: false,
@@ -128,9 +131,7 @@ export function small_full_filters() {
 export function large_full_filters() {
   const url = buildUrl('/people')
   const body = JSON.stringify({
-    state: 'OH',
-    districtType: 'City',
-    districtName: 'COLUMBUS CITY (EST.)',
+    districtId: DISTRICT_LARGE_FILTERS,
     filters: {
       hasCellPhone: true,
       hasLandline: false,

--- a/perf/sample-get.ts
+++ b/perf/sample-get.ts
@@ -2,6 +2,12 @@ import http from 'k6/http'
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { buildUrl, recordMetrics, buildHeaders } = require('./common.js')
 
+// Replace these with real district UUIDs from your database
+const DISTRICT_SMALL =
+  __ENV.DISTRICT_SMALL || 'd79c532c-ee5f-cf01-758f-bd62d4fca41c'
+const DISTRICT_LARGE =
+  __ENV.DISTRICT_LARGE || '26ed9bda-c642-52c0-bb11-7ba46ba86e69'
+
 const baseScenarios = {
   small: { executor: 'constant-vus', vus: 3, duration: '30s', exec: 'small' },
   large: {
@@ -23,9 +29,7 @@ export const options =
 export function small() {
   const url = buildUrl('/people/sample')
   const body = JSON.stringify({
-    state: 'FL',
-    districtType: 'City',
-    districtName: 'NICEVILLE CITY (EST.)',
+    districtId: DISTRICT_SMALL,
     size: 1000,
   })
   const res = http.post(url, body, {
@@ -40,9 +44,7 @@ export function small() {
 export function large() {
   const url = buildUrl('/people/sample')
   const body = JSON.stringify({
-    state: 'FL',
-    districtType: 'City',
-    districtName: 'JACKSONVILLE CITY (EST.)',
+    districtId: DISTRICT_LARGE,
     size: 1000,
   })
   const res = http.post(url, body, {

--- a/perf/stats-get.ts
+++ b/perf/stats-get.ts
@@ -2,6 +2,11 @@ import http from 'k6/http'
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { buildUrl, recordMetrics, buildHeaders } = require('./common.js')
 
+const DISTRICT_SMALL =
+  __ENV.DISTRICT_SMALL || 'd79c532c-ee5f-cf01-758f-bd62d4fca41c'
+const DISTRICT_LARGE =
+  __ENV.DISTRICT_LARGE || '47b7b5fb-5edf-70dc-5448-ef5f545a4793'
+
 const baseScenarios = {
   small: { executor: 'constant-vus', vus: 3, duration: '30s', exec: 'small' },
   large: {
@@ -22,9 +27,7 @@ export const options =
 
 export function small() {
   const url = buildUrl('/people/stats', {
-    state: 'WI',
-    districtType: 'City',
-    districtName: 'ONALASKA CITY',
+    districtId: DISTRICT_SMALL,
   })
   const res = http.get(url, { headers: buildHeaders('perf:stats small') })
   recordMetrics(res)
@@ -32,9 +35,7 @@ export function small() {
 
 export function large() {
   const url = buildUrl('/people/stats', {
-    state: 'WI',
-    districtType: 'City',
-    districtName: 'MILWAUKEE CITY',
+    districtId: DISTRICT_LARGE,
   })
   const res = http.get(url, { headers: buildHeaders('perf:stats large') })
   recordMetrics(res)

--- a/src/district/services/district.service.ts
+++ b/src/district/services/district.service.ts
@@ -1,5 +1,4 @@
 import { Injectable, NotFoundException } from '@nestjs/common'
-import { $Enums } from '@prisma/client'
 import { createPrismaBase, MODELS } from 'src/prisma/util/prisma.util'
 
 export interface DistrictById {
@@ -26,29 +25,5 @@ export class DistrictService extends createPrismaBase(MODELS.District) {
       name,
       state,
     }
-  }
-
-  async findDistrictId(typeNameState: {
-    state: string
-    type: string
-    name: string
-  }) {
-    const { state, type, name } = typeNameState
-    const district = await this.model.findUnique({
-      where: {
-        type_name_state: {
-          type,
-          name,
-          state: state as $Enums.DistrictUSState,
-        },
-      },
-      select: { id: true },
-    })
-    if (!district?.id) {
-      throw new NotFoundException(
-        `District not found for state=${state} type=${type} name=${name}`,
-      )
-    }
-    return district.id
   }
 }

--- a/src/people/people.schema.test.ts
+++ b/src/people/people.schema.test.ts
@@ -4,78 +4,44 @@ import {
   getPersonQuerySchema,
   listPeopleSchema,
   samplePeopleSchema,
-  STATE_DISTRICT_TYPE,
   StatsDTO,
 } from './people.schema'
 
 const DISTRICT_ID = '0e5bafca-93a9-86a5-2522-f373979720df'
 
 describe('people query schemas', () => {
-  it('accepts districtId-only list query', () => {
+  it('accepts districtId list query', () => {
     const parsed = listPeopleSchema.parse({
       districtId: DISTRICT_ID,
       filters: {},
     })
 
     expect(parsed.districtId).toBe(DISTRICT_ID)
-    expect(parsed.state).toBeUndefined()
-    expect(parsed.districtType).toBeUndefined()
-    expect(parsed.districtName).toBeUndefined()
   })
 
-  it('accepts state + districtType + districtName list query', () => {
-    const parsed = listPeopleSchema.parse({
-      state: 'wy',
-      districtType: 'City_Ward',
-      districtName: 'CHEYENNE CITY WARD 1',
-      filters: {},
-    })
-
-    expect(parsed.state).toBe('WY')
-    expect(parsed.districtType).toBe('City_Ward')
-    expect(parsed.districtName).toBe('CHEYENNE CITY WARD 1')
-  })
-
-  it('accepts state-only list query without district normalization', () => {
-    const parsed = listPeopleSchema.parse({
-      state: 'wy',
-      filters: {},
-    })
-
-    expect(parsed.state).toBe('WY')
-    expect(parsed.districtType).toBeUndefined()
-    expect(parsed.districtName).toBeUndefined()
-  })
-
-  it('rejects mixed districtId + districtType/name list query', () => {
+  it('rejects missing districtId', () => {
     expect(() =>
       listPeopleSchema.parse({
-        districtId: DISTRICT_ID,
-        districtType: 'City_Ward',
-        districtName: 'CHEYENNE CITY WARD 1',
         filters: {},
       }),
     ).toThrow()
   })
 
-  it('rejects statewide district with mismatched districtName', () => {
+  it('rejects invalid districtId format', () => {
     expect(() =>
       listPeopleSchema.parse({
-        state: 'WY',
-        districtType: STATE_DISTRICT_TYPE,
-        districtName: 'CO',
+        districtId: 'not-a-uuid',
         filters: {},
       }),
-    ).toThrow('When districtType is State, districtName must equal state')
+    ).toThrow()
   })
 
-  it('accepts districtId-only stats query', () => {
+  it('accepts districtId stats query', () => {
     const parsed = StatsDTO.create({ districtId: DISTRICT_ID })
     expect(parsed.districtId).toBe(DISTRICT_ID)
-    expect(parsed.state).toBeUndefined()
   })
 
-  it('accepts districtId-only sample query', () => {
+  it('accepts districtId sample query', () => {
     const parsed = samplePeopleSchema.parse({
       districtId: DISTRICT_ID,
       size: 25,
@@ -84,20 +50,18 @@ describe('people query schemas', () => {
     expect(parsed.size).toBe(25)
   })
 
-  it('accepts districtId-only download query', () => {
+  it('accepts districtId download query', () => {
     const parsed = downloadPeopleSchema.parse({
       districtId: DISTRICT_ID,
       filters: {},
     })
     expect(parsed.districtId).toBe(DISTRICT_ID)
-    expect(parsed.state).toBeUndefined()
   })
 
-  it('accepts districtId-only getPerson query', () => {
+  it('accepts districtId getPerson query', () => {
     const parsed = getPersonQuerySchema.parse({
       districtId: DISTRICT_ID,
     })
     expect(parsed.districtId).toBe(DISTRICT_ID)
-    expect(parsed.state).toBeUndefined()
   })
 })

--- a/src/people/people.schema.ts
+++ b/src/people/people.schema.ts
@@ -1,59 +1,10 @@
 import { createZodDto } from 'nestjs-zod'
-import { USState } from '@prisma/client'
 import { z } from 'zod'
 
 import { filtersSchema } from './schemas/filters.schema'
 
-export const STATE_DISTRICT_TYPE = 'State'
-
-const stateSchema = z.preprocess(
-  (v) => (typeof v === 'string' ? v.toUpperCase() : v),
-  z.nativeEnum(USState),
-)
-
-const districtIdSchema = z.string().uuid().optional()
-
-const districtEitherRefine = (v: {
-  districtId?: string
-  state?: string
-  districtType?: string
-  districtName?: string
-}) =>
-  (!!v.districtId && !v.state && !v.districtType && !v.districtName) ||
-  (!!v.state && !v.districtId && !!v.districtType && !!v.districtName) ||
-  (!!v.state && !v.districtId && !v.districtType && !v.districtName)
-
-const districtEitherMessage =
-  'Either districtId only, or state + districtType + districtName, or state only'
-
-const districtStateNameRefine = (v: {
-  districtType?: string
-  districtName?: string
-  state?: string
-}) =>
-  v.districtType !== STATE_DISTRICT_TYPE ||
-  (v.districtName != null &&
-    v.state != null &&
-    v.districtName.toUpperCase() === v.state.toUpperCase())
-
-const districtStateNameMessage =
-  'When districtType is State, districtName must equal state'
-
-const districtInputShape = {
-  state: stateSchema.optional(),
-  districtId: districtIdSchema,
-  districtType: z.string().optional(),
-  districtName: z.string().optional(),
-}
-
 const withDistrictInput = <T extends z.ZodRawShape>(shape: T) =>
-  z
-    .object({
-      ...districtInputShape,
-      ...shape,
-    })
-    .refine(districtEitherRefine, districtEitherMessage)
-    .refine(districtStateNameRefine, districtStateNameMessage)
+  z.object({ districtId: z.string().uuid() }).extend(shape)
 
 export const listPeopleSchema = withDistrictInput({
   filters: filtersSchema,
@@ -65,8 +16,6 @@ export const listPeopleSchema = withDistrictInput({
 export class ListPeopleDTO extends createZodDto(listPeopleSchema) {}
 
 export const downloadPeopleSchema = withDistrictInput({
-  electionLocation: z.string().optional(),
-  electionType: z.string().optional(),
   filters: filtersSchema,
 })
 

--- a/src/people/services/people.service.test.ts
+++ b/src/people/services/people.service.test.ts
@@ -52,7 +52,6 @@ describe('PeopleService', () => {
   let mockSampleService: { samplePeople: ReturnType<typeof vi.fn> }
   let mockDistrictService: {
     findDistrictById: ReturnType<typeof vi.fn>
-    findDistrictId: ReturnType<typeof vi.fn>
   }
   let mockStatsService: {
     getTotalCounts: ReturnType<typeof vi.fn>
@@ -72,7 +71,6 @@ describe('PeopleService', () => {
         name: 'CHEYENNE CITY WARD 1',
         state: 'WY',
       }),
-      findDistrictId: vi.fn().mockResolvedValue('district-by-type-name'),
     }
     mockStatsService = {
       getTotalCounts: vi.fn().mockResolvedValue({
@@ -97,7 +95,7 @@ describe('PeopleService', () => {
   })
 
   describe('findPeople query modes and pagination', () => {
-    it('uses districtId-only path via findDistrictById and fast count path', async () => {
+    it('resolves district by id and uses fast count path', async () => {
       mockClient.$queryRaw.mockResolvedValueOnce([makeDbPerson()])
 
       const result = await service.findPeople({
@@ -110,7 +108,6 @@ describe('PeopleService', () => {
       expect(mockDistrictService.findDistrictById).toHaveBeenCalledWith(
         '0e5bafca-93a9-86a5-2522-f373979720df',
       )
-      expect(mockDistrictService.findDistrictId).not.toHaveBeenCalled()
       expect(mockStatsService.getTotalCounts).toHaveBeenCalledWith(
         '0e5bafca-93a9-86a5-2522-f373979720df',
       )
@@ -119,43 +116,24 @@ describe('PeopleService', () => {
       expect(result.people.length).toBeGreaterThan(0)
     })
 
-    it('uses state+type+name path via findDistrictId', async () => {
-      mockClient.$queryRaw.mockResolvedValueOnce([makeDbPerson()])
-
-      const result = await service.findPeople({
+    it('uses voter-only path for state district', async () => {
+      mockDistrictService.findDistrictById.mockResolvedValue({
+        id: 'district-wy',
+        type: 'State',
+        name: 'WY',
         state: 'WY',
-        districtType: 'City_Ward',
-        districtName: 'CHEYENNE CITY WARD 1',
-        filters: { filters: [], filterOperators: {} },
-        resultsPerPage: 10,
-        page: 1,
-      } as never)
-
-      expect(mockDistrictService.findDistrictId).toHaveBeenCalledWith({
-        state: 'WY',
-        type: 'City_Ward',
-        name: 'CHEYENNE CITY WARD 1',
       })
-      expect(mockStatsService.getTotalCounts).toHaveBeenCalledWith(
-        'district-by-type-name',
-      )
-      expect(result.pagination.totalResults).toBe(120)
-    })
-
-    it('uses voter-only state path when only state is provided', async () => {
       mockClient.$queryRaw
         .mockResolvedValueOnce([{ voter_count: 42n }])
         .mockResolvedValueOnce([makeDbPerson({ id: 'person-2' })])
 
       const result = await service.findPeople({
-        state: 'WY',
+        districtId: 'district-wy',
         filters: { filters: [], filterOperators: {} },
         resultsPerPage: 10,
         page: 1,
       } as never)
 
-      expect(mockDistrictService.findDistrictById).not.toHaveBeenCalled()
-      expect(mockDistrictService.findDistrictId).not.toHaveBeenCalled()
       expect(mockStatsService.getTotalCounts).not.toHaveBeenCalled()
       expect(result.pagination.totalResults).toBe(42)
       expect(result.people[0]?.id).toBe('person-2')
@@ -223,7 +201,7 @@ describe('PeopleService', () => {
   })
 
   describe('findPerson', () => {
-    it('returns person for districtId-only path', async () => {
+    it('returns person for district path', async () => {
       mockClient.$queryRaw.mockResolvedValueOnce([makeDbPerson({ id: 'person-ok' })])
 
       const person = await service.findPerson('person-ok', {
@@ -235,7 +213,7 @@ describe('PeopleService', () => {
       expect(mockDistrictService.findDistrictById).toHaveBeenCalled()
     })
 
-    it('returns district-specific not found message for district-bound query', async () => {
+    it('returns district-specific not found message for non-state district', async () => {
       mockClient.$queryRaw.mockResolvedValueOnce([])
 
       await expect(
@@ -245,11 +223,19 @@ describe('PeopleService', () => {
       ).rejects.toThrow(new NotFoundException('Person not found in district'))
     })
 
-    it('returns generic not found message for voter-only query', async () => {
+    it('returns generic not found message for state district', async () => {
+      mockDistrictService.findDistrictById.mockResolvedValue({
+        id: 'district-wy',
+        type: 'State',
+        name: 'WY',
+        state: 'WY',
+      })
       mockClient.$queryRaw.mockResolvedValueOnce([])
 
       await expect(
-        service.findPerson('person-1', { state: 'WY' } as never),
+        service.findPerson('person-1', {
+          districtId: 'district-wy',
+        } as never),
       ).rejects.toThrow(new NotFoundException('Person with ID person-1 not found'))
     })
   })

--- a/src/people/services/people.service.ts
+++ b/src/people/services/people.service.ts
@@ -61,22 +61,21 @@ export class PeopleService extends createPrismaBase(MODELS.Voter) {
     const resolved = await resolveDistrict(this.districtService, query)
     const { districtId, state, useVoterOnlyPath } = resolved
     const select = buildVoterSelectSql().sql
-    const districtExistsClause =
-      districtId && !useVoterOnlyPath
-        ? Prisma.sql`AND EXISTS (
+    const districtExistsClause = !useVoterOnlyPath
+      ? Prisma.sql`AND EXISTS (
             SELECT 1
             FROM green."DistrictVoter" dv
             JOIN green."District" d ON d."id" = dv."district_id"
             WHERE dv."voter_id" = v."id"
               AND d."id" = ${districtId}::uuid
           )`
-        : Prisma.empty
+      : Prisma.empty
 
     const result = await this.client.$queryRaw<BaseDbPerson[]>(
       Prisma.sql`${select} FROM "green"."Voter" v WHERE v."id" = ${id}::uuid AND v."State" = CAST(${state}::text AS "public"."USState") ${districtExistsClause}`,
     )
     if (!result.length) {
-      if (districtId && !useVoterOnlyPath) {
+      if (!useVoterOnlyPath) {
         throw new NotFoundException('Person not found in district')
       }
       throw new NotFoundException(`Person with ID ${id} not found`)
@@ -133,9 +132,8 @@ export class PeopleService extends createPrismaBase(MODELS.Voter) {
   }
 
   async streamPeopleCsv(dto: DownloadPeopleDTO, res: FastifyReply) {
-    const resolved = await resolveDistrict(this.districtService, dto)
     const { state, useVoterOnlyPath, districtId, districtType, districtName } =
-      resolved
+      await resolveDistrict(this.districtService, dto)
     const { filters } = dto
     const effectiveDistrictId = useVoterOnlyPath ? null : districtId
     const whereClause = this.rawBuildWhere({
@@ -214,8 +212,8 @@ export class PeopleService extends createPrismaBase(MODELS.Voter) {
           for (const key of columnNames) {
             row[key] = person[key as keyof typeof person] as CsvValue
           }
-          row.electionLocation = districtName ?? ''
-          row.electionType = districtType ?? ''
+          row.electionLocation = districtName
+          row.electionType = districtType
 
           const canContinue = csvStream.write(row)
           if (!canContinue) {

--- a/src/people/services/sample.service.test.ts
+++ b/src/people/services/sample.service.test.ts
@@ -1,13 +1,11 @@
 import { BadRequestException } from '@nestjs/common'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { STATE_DISTRICT_TYPE } from '../people.schema'
 import { SampleService } from './sample.service'
 
 describe('SampleService', () => {
   let service: SampleService
   let mockDistrictService: {
     findDistrictById: ReturnType<typeof vi.fn>
-    findDistrictId: ReturnType<typeof vi.fn>
   }
   let mockStatsService: {
     getTotalCounts: ReturnType<typeof vi.fn>
@@ -24,7 +22,6 @@ describe('SampleService', () => {
         name: 'CHEYENNE CITY WARD 1',
         state: 'WY',
       }),
-      findDistrictId: vi.fn().mockResolvedValue('statewide-district-id'),
     }
 
     mockStatsService = {
@@ -60,7 +57,7 @@ describe('SampleService', () => {
     })
   }
 
-  it('uses district mode for districtId-only queries', async () => {
+  it('uses district mode for non-state district', async () => {
     wireTransactionResults([[{ id: 'person-1', State: 'WY' }]])
 
     const result = await service.samplePeople({
@@ -72,31 +69,31 @@ describe('SampleService', () => {
     expect(mockDistrictService.findDistrictById).toHaveBeenCalledWith(
       '0e5bafca-93a9-86a5-2522-f373979720df',
     )
-    expect(mockDistrictService.findDistrictId).not.toHaveBeenCalled()
     expect(mockStatsService.getTotalCounts).toHaveBeenCalledWith(
       '0e5bafca-93a9-86a5-2522-f373979720df',
     )
     expect(result).toHaveLength(1)
   })
 
-  it('uses state-only mode and resolves statewide district id when only state is provided', async () => {
+  it('uses state-only mode for state district', async () => {
+    mockDistrictService.findDistrictById.mockResolvedValue({
+      id: 'district-wy',
+      type: 'State',
+      name: 'WY',
+      state: 'WY',
+    })
     wireTransactionResults([[{ id: 'person-2', State: 'WY' }]])
 
     const result = await service.samplePeople({
-      state: 'WY',
+      districtId: 'district-wy',
       size: 1,
       hasCellPhone: false,
     })
 
-    expect(mockDistrictService.findDistrictById).not.toHaveBeenCalled()
-    expect(mockDistrictService.findDistrictId).toHaveBeenCalledWith({
-      state: 'WY',
-      type: STATE_DISTRICT_TYPE,
-      name: 'WY',
-    })
-    expect(mockStatsService.getTotalCounts).toHaveBeenCalledWith(
-      'statewide-district-id',
+    expect(mockDistrictService.findDistrictById).toHaveBeenCalledWith(
+      'district-wy',
     )
+    expect(mockStatsService.getTotalCounts).toHaveBeenCalledWith('district-wy')
     expect(result).toHaveLength(1)
   })
 

--- a/src/people/services/sample.service.ts
+++ b/src/people/services/sample.service.ts
@@ -1,7 +1,7 @@
 import { BadRequestException, Injectable } from '@nestjs/common'
 import { Prisma } from '@prisma/client'
 import { createPrismaBase, MODELS } from 'src/prisma/util/prisma.util'
-import { samplePeopleSchema, STATE_DISTRICT_TYPE } from '../people.schema'
+import { samplePeopleSchema } from '../people.schema'
 import { BaseDbPerson, buildVoterSelectSql } from '../people.select'
 import { DistrictService } from 'src/district/services/district.service'
 import { z } from 'zod'
@@ -103,7 +103,7 @@ export class SampleService extends createPrismaBase(MODELS.Voter) {
     const hasCellPhone = dto.hasCellPhone ?? true
     const excludeIds = dto.excludeIds ?? []
 
-    const seed = hash32(`${resolvedDistrictId ?? state}:${Date.now() / 60_000}`)
+    const seed = hash32(`${resolvedDistrictId}:${Date.now() / 60_000}`)
 
     const outerWhereClause = this.buildOuterWhereSql(state, hasCellPhone)
     const { sql: voterSelect } = buildVoterSelectSql()
@@ -113,18 +113,12 @@ export class SampleService extends createPrismaBase(MODELS.Voter) {
           kind: 'stateOnly',
           state,
           hasCellPhone,
-          districtId:
-            resolvedDistrictId ??
-            (await this.districtService.findDistrictId({
-              state,
-              type: STATE_DISTRICT_TYPE,
-              name: state,
-            })),
+          districtId: resolvedDistrictId,
         }
       : {
           kind: 'district',
           state,
-          districtId: resolvedDistrictId!,
+          districtId: resolvedDistrictId,
         }
     const { districtId } = mode
 

--- a/src/people/services/stats.service.test.ts
+++ b/src/people/services/stats.service.test.ts
@@ -4,9 +4,6 @@ import { StatsService } from './stats.service'
 
 describe('StatsService', () => {
   let service: StatsService
-  let mockDistrictService: {
-    findDistrictId: ReturnType<typeof vi.fn>
-  }
   let mockPrisma: {
     districtStats: {
       findUnique: ReturnType<typeof vi.fn>
@@ -14,23 +11,20 @@ describe('StatsService', () => {
   }
 
   beforeEach(() => {
-    mockDistrictService = {
-      findDistrictId: vi.fn().mockResolvedValue('district-by-type-name'),
-    }
     mockPrisma = {
       districtStats: {
         findUnique: vi.fn(),
       },
     }
 
-    service = new StatsService(mockDistrictService as never)
+    service = new StatsService()
     Object.defineProperty(service, '_prisma', {
       get: () => mockPrisma,
       configurable: true,
     })
   })
 
-  it('uses districtId directly when provided', async () => {
+  it('uses districtId directly', async () => {
     mockPrisma.districtStats.findUnique.mockResolvedValue({
       districtId: 'district-1',
       totalConstituents: 100,
@@ -40,49 +34,10 @@ describe('StatsService', () => {
       districtId: 'district-1',
     } as never)
 
-    expect(mockDistrictService.findDistrictId).not.toHaveBeenCalled()
     expect(mockPrisma.districtStats.findUnique).toHaveBeenCalledWith({
       where: { districtId: 'district-1' },
     })
     expect(result.districtId).toBe('district-1')
-  })
-
-  it('resolves districtId from state/type/name when districtId is absent', async () => {
-    mockPrisma.districtStats.findUnique.mockResolvedValue({
-      districtId: 'district-by-type-name',
-      totalConstituents: 200,
-    })
-
-    const result = await service.getStats({
-      state: 'WY',
-      districtType: 'City_Ward',
-      districtName: 'CHEYENNE CITY WARD 1',
-    } as never)
-
-    expect(mockDistrictService.findDistrictId).toHaveBeenCalledWith({
-      state: 'WY',
-      type: 'City_Ward',
-      name: 'CHEYENNE CITY WARD 1',
-    })
-    expect(result.districtId).toBe('district-by-type-name')
-  })
-
-  it('resolves districtId from state-only using statewide district', async () => {
-    mockPrisma.districtStats.findUnique.mockResolvedValue({
-      districtId: 'district-by-type-name',
-      totalConstituents: 250,
-    })
-
-    const result = await service.getStats({
-      state: 'WY',
-    } as never)
-
-    expect(mockDistrictService.findDistrictId).toHaveBeenCalledWith({
-      state: 'WY',
-      type: 'State',
-      name: 'WY',
-    })
-    expect(result.districtId).toBe('district-by-type-name')
   })
 
   it('throws NotFoundException when stats are missing', async () => {

--- a/src/people/services/stats.service.ts
+++ b/src/people/services/stats.service.ts
@@ -1,37 +1,18 @@
 import { Injectable, NotFoundException } from '@nestjs/common'
 import { DistrictStats } from '@prisma/client'
 import { createPrismaBase, MODELS } from 'src/prisma/util/prisma.util'
-import { STATE_DISTRICT_TYPE, StatsDTO } from '../people.schema'
-import { DistrictService } from 'src/district/services/district.service'
+import { StatsDTO } from '../people.schema'
 
 @Injectable()
 export class StatsService extends createPrismaBase(MODELS.DistrictStats) {
-  constructor(private readonly districtService: DistrictService) {
-    super()
-  }
-
   async getStats(dto: StatsDTO): Promise<DistrictStats> {
-    const { districtId: dtoDistrictId, state, districtType, districtName } = dto
-    const districtId = dtoDistrictId
-      ? dtoDistrictId
-      : await this.districtService.findDistrictId(
-          districtType && districtName
-            ? {
-                state: state!,
-                type: districtType,
-                name: districtName,
-              }
-            : {
-                state: state!,
-                type: STATE_DISTRICT_TYPE,
-                name: state!,
-              },
-        )
-    const stats = await this.model.findUnique({ where: { districtId } })
+    const stats = await this.model.findUnique({
+      where: { districtId: dto.districtId },
+    })
 
     if (!stats) {
       throw new NotFoundException(
-        `District stats not found for districtId=${districtId}`,
+        `District stats not found for districtId=${dto.districtId}`,
       )
     }
 

--- a/src/people/utils/resolveDistrict.utils.test.ts
+++ b/src/people/utils/resolveDistrict.utils.test.ts
@@ -1,10 +1,8 @@
-import { BadRequestException } from '@nestjs/common'
 import { describe, expect, it, vi } from 'vitest'
-import { STATE_DISTRICT_TYPE } from '../people.schema'
 import { resolveDistrict } from './resolveDistrict.utils'
 
 describe('resolveDistrict', () => {
-  it('resolves districtId-only query via district lookup', async () => {
+  it('resolves district and returns state from lookup', async () => {
     const districtService = {
       findDistrictById: vi.fn().mockResolvedValue({
         id: '0e5bafca-93a9-86a5-2522-f373979720df',
@@ -12,7 +10,6 @@ describe('resolveDistrict', () => {
         name: 'CHEYENNE CITY WARD 1',
         state: 'WY',
       }),
-      findDistrictId: vi.fn(),
     }
 
     const resolved = await resolveDistrict(districtService as never, {
@@ -22,7 +19,6 @@ describe('resolveDistrict', () => {
     expect(districtService.findDistrictById).toHaveBeenCalledWith(
       '0e5bafca-93a9-86a5-2522-f373979720df',
     )
-    expect(districtService.findDistrictId).not.toHaveBeenCalled()
     expect(resolved).toEqual({
       districtId: '0e5bafca-93a9-86a5-2522-f373979720df',
       state: 'WY',
@@ -32,15 +28,14 @@ describe('resolveDistrict', () => {
     })
   })
 
-  it('marks districtId-only state district as voter-only path', async () => {
+  it('marks state district as voter-only path', async () => {
     const districtService = {
       findDistrictById: vi.fn().mockResolvedValue({
         id: 'district-wy',
-        type: STATE_DISTRICT_TYPE,
+        type: 'State',
         name: 'WY',
         state: 'WY',
       }),
-      findDistrictId: vi.fn(),
     }
 
     const resolved = await resolveDistrict(districtService as never, {
@@ -49,62 +44,5 @@ describe('resolveDistrict', () => {
 
     expect(resolved.useVoterOnlyPath).toBe(true)
     expect(resolved.state).toBe('WY')
-  })
-
-  it('resolves state + districtType + districtName via district id lookup', async () => {
-    const districtService = {
-      findDistrictById: vi.fn(),
-      findDistrictId: vi.fn().mockResolvedValue('district-lookup-id'),
-    }
-
-    const resolved = await resolveDistrict(districtService as never, {
-      state: 'WY',
-      districtType: 'City_Ward',
-      districtName: 'CHEYENNE CITY WARD 1',
-    })
-
-    expect(districtService.findDistrictId).toHaveBeenCalledWith({
-      state: 'WY',
-      type: 'City_Ward',
-      name: 'CHEYENNE CITY WARD 1',
-    })
-    expect(districtService.findDistrictById).not.toHaveBeenCalled()
-    expect(resolved).toEqual({
-      districtId: 'district-lookup-id',
-      state: 'WY',
-      useVoterOnlyPath: false,
-      districtType: 'City_Ward',
-      districtName: 'CHEYENNE CITY WARD 1',
-    })
-  })
-
-  it('uses voter-only path for state-only queries', async () => {
-    const districtService = {
-      findDistrictById: vi.fn(),
-      findDistrictId: vi.fn(),
-    }
-
-    const resolved = await resolveDistrict(districtService as never, {
-      state: 'WY',
-    })
-
-    expect(resolved).toEqual({
-      districtId: null,
-      state: 'WY',
-      useVoterOnlyPath: true,
-    })
-    expect(districtService.findDistrictId).not.toHaveBeenCalled()
-    expect(districtService.findDistrictById).not.toHaveBeenCalled()
-  })
-
-  it('throws for missing district and missing state', async () => {
-    const districtService = {
-      findDistrictById: vi.fn(),
-      findDistrictId: vi.fn(),
-    }
-
-    await expect(resolveDistrict(districtService as never, {})).rejects.toThrow(
-      BadRequestException,
-    )
   })
 })

--- a/src/people/utils/resolveDistrict.utils.ts
+++ b/src/people/utils/resolveDistrict.utils.ts
@@ -1,68 +1,27 @@
-import { BadRequestException } from '@nestjs/common'
 import { DistrictService } from 'src/district/services/district.service'
-import { STATE_DISTRICT_TYPE } from '../people.schema'
 
-export interface ResolveDistrictParams {
-  state?: string
-  districtId?: string
-  districtType?: string
-  districtName?: string
-}
+const STATE_DISTRICT_TYPE = 'State'
 
 export interface ResolvedDistrict {
-  districtId: string | null
+  districtId: string
   state: string
   useVoterOnlyPath: boolean
-  districtType?: string
-  districtName?: string
+  districtType: string
+  districtName: string
 }
 
-export async function resolveDistrict(
+export const resolveDistrict = async (
   districtService: DistrictService,
-  params: ResolveDistrictParams,
-): Promise<ResolvedDistrict> {
-  const { state, districtId, districtType, districtName } = params
-  const byDistrictId = !!districtId && !districtType && !districtName
-  const byTypeName = !!state && !!districtType && !!districtName
-
-  if (byDistrictId) {
-    const district = await districtService.findDistrictById(districtId!)
-    const { id, type, name, state: districtState } = district
-    return {
-      districtId: id,
-      state: districtState,
-      useVoterOnlyPath: type === STATE_DISTRICT_TYPE && name === districtState,
-      districtType: type,
-      districtName: name,
-    }
-  }
-
-  if (byTypeName) {
-    const resolvedId = await districtService.findDistrictId({
-      state: state!,
-      type: districtType!,
-      name: districtName!,
-    })
-    return {
-      districtId: resolvedId,
-      state: state!,
-      useVoterOnlyPath:
-        districtType === STATE_DISTRICT_TYPE && districtName === state,
-      districtType,
-      districtName,
-    }
-  }
-
-  const stateOnlyState = state ?? ''
-  if (!stateOnlyState) {
-    throw new BadRequestException(
-      'state is required when district is not specified by districtId or by state+districtType+districtName',
-    )
-  }
-
+  params: { districtId: string },
+): Promise<ResolvedDistrict> => {
+  const { id, type, name, state } = await districtService.findDistrictById(
+    params.districtId,
+  )
   return {
-    districtId: null,
-    state: stateOnlyState,
-    useVoterOnlyPath: true,
+    districtId: id,
+    state,
+    useVoterOnlyPath: type === STATE_DISTRICT_TYPE && name === state,
+    districtType: type,
+    districtName: name,
   }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> This is a behavior/contract change: people/stats/sample/download queries now require a UUID `districtId`, removing state/type/name and state-only inputs, which can break existing clients and alter query paths (notably for state districts). Risk is limited to request validation and district resolution logic; core data writes are unaffected.
> 
> **Overview**
> **Standardizes district selection on `districtId` only.** All People-related DTO/schemas now require a UUID `districtId`, removing support for `state`, `districtType`, and `districtName` inputs and deleting `DistrictService.findDistrictId` plus the associated resolution logic.
> 
> People/Stats/Sample services and tests are updated to resolve districts exclusively via `findDistrictById`, treating `type === "State"` districts as a special *voter-only* path; CSV export now writes `electionLocation`/`electionType` directly from the resolved district values. API examples and k6 perf scripts are updated to use `districtId` (with env overrides for test districts).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1a3151abcca4fce596a817aa1f40d9f36194004e. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->