### PR TITLE
Prod <- QA

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,116 +1,99 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Guidance for Claude Code and other AI agents working in `people-api`. Keep this file short — push detail into `docs/`.
 
-## Overview
+## Project
 
-people-api is a NestJS/Fastify internal API serving 200M+ US voter records sourced from L2 (voter data vendor). It is called exclusively by gp-api via S2S JWT authentication — there are no end-user-facing routes.
+NestJS/Fastify internal API serving 200M+ US voter records sourced from L2 (a voter-data vendor). Called exclusively by `gp-api` via S2S JWT — no end-user-facing routes. Postgres via Prisma; the `Voter` table lives in the `green` schema and is partitioned by state.
 
-## Commands
+## Commands (most-used first)
 
 ```bash
-npm run start:dev          # Dev server on :3002 (watches for changes)
-npm run build              # Production build (nest build)
-npm run test               # Run all tests (vitest run)
-npm run test:watch         # Watch mode (vitest)
-npx vitest run src/people/utils/filters.sql.utils.test.ts  # Single test file
-npm run lint               # ESLint with --fix
-npm run format             # Prettier
-npm run migrate:dev        # Prisma migrate dev
-npm run migrate:deploy     # Prisma migrate deploy (production)
-npm run generate           # Prisma generate (after schema changes)
-npm run seed               # Seed database
+npm run start:dev              # Dev server (:3002) with watch
+npm test                       # vitest run
+npx vitest run src/people/utils/filters.sql.utils.test.ts   # single file
+npm run test:watch             # watch mode
+npm run lint                   # eslint --fix on {src,apps,libs,test}/**/*.ts
+npm run lint-format            # lint + prettier --write
+npm run build                  # nest build → dist/
+
+npm run migrate:dev            # create/apply a migration
+npm run migrate:reset          # reset DB + migrate (LOCAL ONLY)
+npm run migrate:deploy         # apply pending migrations (CI/prod)
+npm run generate               # regenerate Prisma client
+npm run seed                   # @faker-js seed (local dev only)
+
+npm run ai-rules:update        # advance the ai-rules submodule pin
 ```
 
-## Architecture
+`npm run lint` runs `eslint --fix` — it mutates files. Stage your work first.
 
-### Module Structure
+## Pointer table — when in doubt
+
+| Doing | Read |
+|-------|------|
+| Adding an endpoint / module | `docs/architecture.md` § Module shape |
+| Touching the voter data flow | `docs/data-pipeline.md` |
+| First-time setup | `docs/getting-started.md` |
+| AI rule-by-rule code review | `ai-rules/` (git submodule) |
+
+## Code style
+
+- **No semicolons**, single quotes, trailing commas (`.prettierrc`)
+- `unused-imports/no-unused-imports` is an **error**
+- `@typescript-eslint/no-explicit-any` is **off** — prefer typed code anyway, treat `any` as a last resort.
+- TypeScript: `strict: true`, `strictNullChecks: true`, `noImplicitAny: false`, `baseUrl: ./` so imports look like `import { X } from 'src/<feature>/...'`.
+- Arrow functions over `function` declarations
+- **No comments in code** unless the WHY is non-obvious
+
+## Module shape
 
 ```
-AppModule
-├── PrismaModule (@Global) → PrismaService
-├── AuthModule → S2SAuthGuard (global APP_GUARD)
-├── HealthModule → GET /v1/health (@Public)
-└── PeopleModule
-    ├── PeopleController (/v1/people)
-    ├── PeopleService → raw SQL queries against partitioned Voter table
-    ├── SampleService → deterministic hash-bucket sampling
-    ├── StatsService → pre-computed district demographics from DistrictStats
-    └── DistrictModule → DistrictService
+src/<feature>/
+├── <feature>.module.ts
+├── <feature>.controller.ts        # HTTP only — no business logic
+├── services/<X>.service.ts        # extends createPrismaBase(MODELS.X) where applicable
+├── schemas/<X>.schema.ts          # Zod (createZodDto)
+├── utils/<X>.utils.ts             # pure helpers
+└── <feature>.schema.ts            # top-level DTO schema
 ```
 
-### API Endpoints (all under `/v1/people`)
+`src/people/` is the canonical reference (controller + multiple services + filter utils + Zod schemas + tests).
 
-| Method | Path | Purpose |
-|--------|------|---------|
-| POST | `/people` | List/filter voters with pagination |
-| POST | `/people/download` | Stream filtered voters as CSV |
-| GET/POST | `/people/sample` | Deterministic voter sampling for a district |
-| GET | `/people/stats` | Pre-computed district demographic stats |
-| GET | `/people/:id` | Single voter by ID |
+## PrismaBase pattern
 
-### Database & Prisma
+Services backed by a Prisma model **must** extend `createPrismaBase(MODELS.ModelName)` from `src/prisma/util/prisma.util.ts`. Provides `this.model`, `this.client`, `this.logger`, and bound passthroughs (`findMany`, `findFirst`, `findUnique`, `count`, etc.). **Never inject `PrismaService` directly into a new service.**
 
-Multi-file schema in `prisma/schema/` using `prismaSchemaFolder` and `multiSchema` preview features. Two PostgreSQL schemas: `public` (enums) and `green` (all tables).
+## Voter queries are raw SQL
 
-**Models:** Voter (100+ L2 columns, partitioned by state), District, DistrictVoter (join table), DistrictStats (pre-computed demographics with `buckets` JSON column).
+Almost all `Voter` queries go through `Prisma.sql` / `$queryRaw`, not Prisma ORM CRUD. The Voter table has 100+ L2 columns and partitioning by state — the ORM path is too coarse. Filter Zod → `transformFilters` → `buildVoterFiltersSql` → `Prisma.sql` WHERE clauses → execute. Output is normalized via `transformToPersonOutput` before leaving the service.
 
-**Critical pattern:** The Voter table is partitioned by state in the `green` schema. Nearly all voter queries use raw SQL via `Prisma.sql` / `$queryRaw` — not Prisma ORM CRUD methods. Prisma ORM methods are only used for District and DistrictStats lookups.
+`District` and `DistrictStats` use ORM methods — they're small lookup tables.
 
-### createPrismaBase Pattern
+See `docs/data-pipeline.md` for the full pipeline.
 
-All data-access services extend `createPrismaBase(MODELS.ModelName)` from `src/prisma/util/prisma.util.ts`. This factory provides passthrough methods (`findMany`, `findFirst`, `count`, etc.) plus `this.model` and `this.client` accessors. Never inject `PrismaService` directly into new services.
+## Auth
 
-### Filter Pipeline
-
-1. **Zod parsing** (`src/people/schemas/filters.schema.ts`) — validates and transforms raw filter input
-2. **transformFilters** (`src/people/schemas/filters.schema.utils.ts`) — converts to structured `FilterData` with filters, filterValues, filterOperators
-3. **buildVoterFiltersSql** (`src/people/utils/filters.sql.utils.ts`) — converts `FilterData` to `Prisma.Sql` WHERE clauses
-
-### Output Transformation
-
-Raw L2 field names/values are mapped to clean API output via `transformToPersonOutput` in `src/people/utils/transformToPersonOutput.utils.ts`. Mapper functions normalize gender, party, ethnicity, marital status, etc.
-
-### Authentication
-
-`S2SAuthGuard` (global) validates Bearer JWT signed with `PEOPLE_API_S2S_SECRET` (shared with gp-api). Use `@Public()` decorator to bypass auth. Dev env allows localhost bypass via `S2S_ALLOW_LOCALHOST=true`.
-
-### Global Setup (main.ts)
-
-- `ZodValidationPipe` — global validation via Zod schemas
-- `PrismaExceptionFilter` → `AllExceptionsFilter` — exception filter chain
-- `NewRelicInterceptor` — APM transaction names and slow-request events
-- Fastify plugins: `@fastify/helmet`, `@fastify/cors`, `@fastify/cookie`, `@fastify/static`
-- Global prefix: `/v1`
-- Custom `qs` parser for bracketed query params
+`S2SAuthGuard` is the global `APP_GUARD`. Validates Bearer JWTs signed with `PEOPLE_API_S2S_SECRET` (shared with gp-api). Use `@Public()` to bypass (currently only `/v1/health`). `S2S_ALLOW_LOCALHOST=true` in `.env` allows unauthenticated localhost requests for dev.
 
 ## Testing
 
-**Runner:** Vitest with SWC transpiler. Config in `vitest.config.ts`.
+- Framework: **Vitest 4** with SWC (NestJS decorator metadata requires SWC, not esbuild)
+- Test file pattern: `*.test.ts` (NOT `.spec.ts` — `nest-cli.json` has `spec: false`)
+- Pattern: `Test.createTestingModule` with `useValue`/`useClass` for DI; **fakes over mocks** — reach for `vi.fn()` only for callbacks/event handlers.
 
-**File naming:** `*.test.ts` (not `*.spec.ts`). `nest-cli.json` has `spec: false`.
+## Never
 
-**Patterns:**
-- Use `@nestjs/testing` `Test.createTestingModule` with `useValue`/`useClass` for DI
-- Fakes over mocks — `vi.fn()` only for callbacks/event handlers
-- Follow the rules in `ai-rules/`
-- When writing or modifying code, consider spawning a critic subagent:
-  ```
-  Read each .md file in ai-rules/. For each rule file relevant to my changes,
-  review the code I changed against those rules. For each violation, cite the
-  rule number, quote the offending code, and explain what to change.
-  ```
+- Never edit a file under `prisma/migrations/<timestamp>/` — applied migrations are immutable.
+- Never inject `PrismaService` directly into a new service — always extend `createPrismaBase(MODELS.X)`.
+- Never expose this API publicly. It is internal-only; no end-user-facing routes.
+- Never bypass `S2SAuthGuard` except via the `@Public()` decorator on health-check routes.
+- Never query the `Voter` table via Prisma ORM in new code — use `Prisma.sql` / `$queryRaw`.
+- Never disable `unused-imports/no-unused-imports` without an inline comment justifying it.
 
-## Code Style
+## Environment
 
-- **Formatting:** singleQuote, no semicolons, trailing commas (`"all"`)
-- **No comments in code**
-- ESLint: `no-explicit-any: off`, `unused-imports/no-unused-imports: error`
-- TypeScript: `strict: true`, `strictNullChecks: true`, `noImplicitAny: false`
-
-## Deploy
-
-SST v3 + Pulumi in `deploy/sst.config.ts`. Two stages: `develop` and `master`. ECS Fargate behind ALB. Secrets from AWS Secrets Manager (`PEOPLE_API_DEV` / `PEOPLE_API_PROD`). CI/CD: GitHub Actions triggers CodeBuild on push to develop/master.
-
-- Prod: `people-api.goodparty.org` (4GB, 1 vCPU, 2-16 tasks)
-- Dev: `people-api-dev.goodparty.org` (2GB, 0.5 vCPU, 1-4 tasks)
+- Node `v22.12` (`.nvmrc`)
+- npm
+- Postgres for local dev. The DB needs `green` and `public` schemas (`schemas = ["green", "public"]` in `prisma/schema/schema.prisma`); `npm run migrate:dev` creates them.
+- Required env vars: `DATABASE_URL`, `PEOPLE_API_S2S_SECRET`, `PORT` (code default 3000; `.env.example` sets 3002), `S2S_ALLOW_LOCALHOST` (dev only). See `.env.example`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,98 @@
+# Architecture
+
+A pointer-heavy doc. Detailed conventions live in `CLAUDE.md` and the rule files in `ai-rules/`.
+
+## Stack
+
+- **NestJS 11** on **Fastify** (not Express); `@fastify/helmet`, `@fastify/cors`, `@fastify/cookie`, `@fastify/static`
+- **Prisma 6** with multi-file schema folder + `multiSchema` (two PG schemas: `green` for tables, `public` for enums); `prisma-json-types-generator` for JSON column typing
+- **Zod** via `nestjs-zod` (`createZodDto` + global `ZodValidationPipe`)
+- **Vitest 4** with SWC for tests
+- **OpenTelemetry** (traces/metrics/logs OTLP) wired in `src/otel.ts`; `nestjs-pino` for structured logs
+- **Pulumi** (TypeScript) for IaC under `deploy/`
+
+## Module shape
+
+```
+src/<feature>/
+├── <feature>.module.ts
+├── <feature>.controller.ts        # HTTP only — no business logic
+├── services/<X>.service.ts        # extends createPrismaBase(MODELS.X) where applicable
+├── schemas/<X>.schema.ts          # Zod schemas; createZodDto for DTOs
+├── utils/<X>.utils.ts             # pure helpers (filters, transforms, hashing)
+├── <feature>.schema.ts            # top-level DTOs (re-exports schemas)
+└── <X>.test.ts                    # vitest, colocated
+```
+
+`src/people/` is the canonical reference — it has the controller, three services (`people`, `sample`, `stats`), the filter pipeline, the SQL builder, and the output transformer all in one place.
+
+## App composition
+
+```
+AppModule
+├── loggerModule (nestjs-pino)
+├── PrismaModule (@Global) → PrismaService
+├── HealthModule → GET /v1/health (@Public)
+├── PeopleModule
+│   ├── PeopleController (/v1/people)
+│   ├── PeopleService     (raw SQL voter queries)
+│   ├── SampleService     (deterministic hash-bucket sampling)
+│   ├── StatsService      (pre-computed district demographics)
+│   └── DistrictModule → DistrictService
+└── AuthModule → S2SAuthGuard registered as APP_GUARD
+```
+
+## HTTP surface
+
+All routes are mounted under the global prefix `/v1` (set in `src/main.ts`).
+
+| Method | Path | Module | Notes |
+|--------|------|--------|-------|
+| GET | `/v1/health` | `src/health/` | `@Public()` — bypasses auth |
+| POST | `/v1/people` | `src/people/` | List/filter voters with pagination |
+| POST | `/v1/people/download` | `src/people/` | Stream filtered voters as CSV |
+| GET / POST | `/v1/people/sample` | `src/people/` | Deterministic voter sampling for a district |
+| GET | `/v1/people/stats` | `src/people/` | Pre-computed district demographic stats |
+| GET | `/v1/people/:id` | `src/people/` | Single voter by ID |
+
+Swagger is mounted at `/api` (no prefix) for ad-hoc exploration in non-prod.
+
+## Auth
+
+`S2SAuthGuard` (`src/auth/s2s-auth.guard.ts`) is registered globally as `APP_GUARD` in `AuthModule`. Validates Bearer JWTs signed with `PEOPLE_API_S2S_SECRET` (shared with `gp-api`). The `@Public()` decorator (`src/auth/public.decorator.ts`) opts a route out — currently only `/v1/health`.
+
+In dev, set `S2S_ALLOW_LOCALHOST=true` in `.env` to allow localhost bypass. Even with localhost bypass on, an `Authorization` header still gets validated when present.
+
+## Cross-service edges
+
+| Direction | Service | Protocol | Auth | Notes |
+|-----------|---------|----------|------|-------|
+| inbound | `gp-api` | HTTP (S2S) | Bearer JWT (`PEOPLE_API_S2S_SECRET`) | The only caller in production |
+| outbound | none | — | — | `people-api` does not call out — it's a leaf service |
+
+Voter data is loaded by external ETL (out of this repo). See `docs/data-pipeline.md`.
+
+## Bootstrap
+
+`src/main.ts` is the entry point:
+
+1. Load alias + dotenv (`module-alias`, `src/configrc.ts`)
+2. Create `NestFastifyApplication` with custom `qs` query parser (for bracketed filters like `filter[field][op]`), `genReqId` from `x-request-id`, `rawBody: true`
+3. Swap in `nestjs-pino` as the global logger
+4. Register Fastify OTel instrumentation (when present in global)
+5. Set global prefix `/v1`, register `ZodValidationPipe`, register `PrismaExceptionFilter` then `AllExceptionsFilter` (chained)
+6. Build Swagger doc at `/api`
+7. Register `@fastify/helmet`, `@fastify/cors`, `@fastify/cookie`, `@fastify/static` (serves `public/`)
+8. Listen on `PORT` (default 3000; we deploy on `3002` per `.env`)
+
+## Key patterns
+
+- **`createPrismaBase(MODELS.X)`** (`src/prisma/util/prisma.util.ts`) — every data-access service extends this. Gives `this.model`, `this.client`, `this.logger`, plus bound passthroughs (`findMany`, `findFirst`, `findUnique`, `findUniqueOrThrow`, `count`).
+- **Filter pipeline for `Voter`**: Zod parsing in `src/people/schemas/filters.schema.ts` → `transformFilters` (in `filters.schema.utils.ts`) → `buildVoterFiltersSql` (in `src/people/utils/filters.sql.utils.ts`) → `Prisma.sql` WHERE clauses → `$queryRaw`. Output passes through `transformToPersonOutput` to normalize L2 raw values into clean API shapes.
+- **Deterministic sampling** uses `murmurhash` over `LALVOTERID` + a salt to hash voters into buckets — the same input always yields the same sample (`src/people/services/sample.service.ts`, `src/shared/util/hash.util.ts`).
+- **`PrismaExceptionFilter`** translates Prisma error classes into `HttpException`s before the catch-all `AllExceptionsFilter` runs. Order matters — Prisma filter must run first.
+- **Bracketed-query parsing** uses `qs` (not Fastify's default) so endpoints can accept `filter[party][in]=D,R` cleanly. Configured in the FastifyAdapter options in `src/main.ts`.
+
+## ADRs
+
+`docs/adr/` is not yet seeded. Add one when a non-obvious decision lands (e.g., why raw SQL for `Voter`, why partition by state, why S2S JWT instead of mTLS, why `green`/`public` schema split). Use `ai-rules/adr-template.md`.

--- a/docs/data-pipeline.md
+++ b/docs/data-pipeline.md
@@ -1,0 +1,88 @@
+# Data Pipeline
+
+How voter data gets in, lives, and flows out of `people-api`. **Ingestion happens outside this repo** — `people-api` is read-only from the application's perspective. The model files in `prisma/schema/` describe what the API queries; they do not describe how rows are loaded.
+
+## Source
+
+Voter rows come from **L2** (a commercial voter-data vendor). L2 ships per-state files with ~100+ columns covering voter identity, address, demographics, voting history, and consumer-data overlays.
+
+The README at the repo root references `npm run download` and `npm run load` scripts; those scripts are no longer wired into `package.json` and **are not the current ingestion path**. Treat the README's "Run the downloader / Run the loader" section as historical until it's updated. Current ingestion is operated externally — coordinate with the data team if you need a refresh.
+
+## Storage
+
+Two PostgreSQL schemas configured in `prisma/schema/schema.prisma`:
+
+- **`green`** — all tables (`Voter`, `District`, `DistrictVoter`, `DistrictStats`)
+- **`public`** — enums (`USState`, …)
+
+Splitting enums into `public` lets cross-schema casts and partition-pruning hints work cleanly (see migration `20251209090000_add_usstate_cross_schema_casts`).
+
+### Tables
+
+| Table | Purpose | Notes |
+|-------|---------|-------|
+| `Voter` | One row per registered voter. ~100+ L2 columns. | Natively **partitioned by `State`** at the Postgres level. Prisma sees one table; the planner prunes partitions by the `State` predicate. Migrations under `prisma/migrations/` add partition-aware indexes (e.g., `Voter_last_first_id_idx`). |
+| `District` | Geographic / political districts. | Small lookup table; queried via Prisma ORM. |
+| `DistrictVoter` | Join: which voters belong to which district. | Composite PK `(districtId, voterId)`; `state` is denormalized for partition pruning on cascading deletes. |
+| `DistrictStats` | Pre-computed demographic rollups per district. | Has a `buckets` JSON column typed via `prisma-json-types-generator` (see `districtStats.jsonTypes.d.ts`). |
+
+`Voter.id` is a UUID generated at ingestion. `Voter.LALVOTERID` is L2's permanent voter identifier and is the natural key.
+
+## Read pipeline (the API path)
+
+When a request hits `POST /v1/people` or `POST /v1/people/download`:
+
+```
+HTTP request
+   │
+   ▼  Zod validation (nestjs-zod)
+src/people/schemas/filters.schema.ts
+   │
+   ▼  transformFilters() — group raw query into FilterData
+src/people/schemas/filters.schema.utils.ts
+   │
+   ▼  buildVoterFiltersSql() — convert FilterData to a Prisma.Sql WHERE clause
+src/people/utils/filters.sql.utils.ts
+   │
+   ▼  buildVoterSelectSql() — typed SELECT clause based on requested fields
+src/people/people.select.ts
+   │
+   ▼  $queryRaw against `green.Voter` (joined to `green.DistrictVoter` if filtering by district)
+PrismaService
+   │
+   ▼  transformToPersonOutput() — map raw L2 values to clean API output
+src/people/utils/transformToPersonOutput.utils.ts
+   │
+   ▼  Optional CSV streaming via @fast-csv/format
+HTTP response
+```
+
+Every step except the last one is unit-testable in isolation. `filters.sql.utils.test.ts` and `filters.schema.utils.test.ts` are the canonical examples — they assert the SQL string + parameter array, not just behavior.
+
+### Why raw SQL for `Voter`
+
+Prisma ORM's coverage of partitioned tables is shallow. With ~100+ columns plus dynamic projection (callers pick which fields they want), generated `select` types blow up and the planner doesn't see the partition key as cleanly. Raw SQL via `Prisma.sql` gives us:
+
+- Predicate placement that triggers partition pruning (`State = $1` and friends)
+- Custom column-set projections without overgrowing TypeScript types
+- Index-aligned ORDER BY / pagination
+
+`District` and `DistrictStats` stay on the ORM path — they're small and cheap to read.
+
+## Sampling
+
+`SampleService` (`src/people/services/sample.service.ts`) returns a deterministic subset of voters for a district. It hashes `LALVOTERID + salt` via `murmurhash` (`src/shared/util/hash.util.ts`) into N buckets and selects rows in the requested buckets. Same input → same output, which lets callers (e.g. campaign sampling tools) cache and resume safely.
+
+## Stats
+
+`DistrictStats` is pre-aggregated upstream and stored as one row per district with a `buckets` JSON blob. `StatsService` returns it verbatim — no on-the-fly aggregation in this API. If new stats are needed, they're added by the upstream ETL, not computed here.
+
+## Local dev
+
+There's a `seed/` directory that uses `@faker-js/faker` to generate ~100 fake voters for local exploration. See `seed/README.md`. **Seeding is disabled in `production`, `qa`, and `development` environments** as a safety check.
+
+For real-shaped data, ask the data team — there's no automated dev-snapshot path today.
+
+## Refreshes / cadence
+
+There is no in-repo cron or queue consumer. Refreshes happen externally and are then visible to this API. If you need to know "is this row fresh?", check `Voter.updatedAt` on individual rows.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,121 @@
+# Getting Started
+
+First-time setup for `people-api` on macOS / Linux.
+
+## Prerequisites
+
+- **Node** matching `.nvmrc` (`v22.12`). With `nvm`: `nvm install && nvm use`.
+- **npm** (ships with Node).
+- **PostgreSQL** running locally on `:5432`. Easiest path is Docker:
+  ```bash
+  docker run --name people-api-pg -e POSTGRES_PASSWORD=postgres -p 5432:5432 -d postgres:15
+  ```
+
+## Clone
+
+This repo uses `ai-rules` as a git submodule. Clone with `--recursive`:
+
+```bash
+git clone --recursive git@github.com:thegoodparty/people-api.git
+cd people-api
+```
+
+If you already cloned without `--recursive`:
+
+```bash
+git submodule update --init --recursive
+```
+
+You can also bump the submodule pin to the latest `ai-rules` main with `npm run ai-rules:update`.
+
+## Configure environment
+
+Copy `.env.example` to `.env` and fill in:
+
+```bash
+cp .env.example .env
+```
+
+Required vars (see `.env.example`):
+
+| Var | Default for local | Notes |
+|-----|-------------------|-------|
+| `DATABASE_URL` | `postgresql://postgres:postgres@localhost:5432/...` | Postgres connection string. The DB will host `green` and `public` schemas. |
+| `PEOPLE_API_S2S_SECRET` | `some-secret` | Shared with `gp-api` for Bearer JWT validation. Any non-empty value works locally. |
+| `S2S_ALLOW_LOCALHOST` | `false` (ships as `false` in `.env.example`) | Set to `true` locally to skip JWT signing on localhost requests. **Don't set this on hosted envs.** |
+| `PORT` | `3002` | App port |
+| `CORS_ORIGIN` | `http://localhost:4000` | Origin allowed by Fastify CORS |
+| `LOG_LEVEL` | `debug` | Pino log level |
+
+## Database setup
+
+If your local Postgres user lacks privileges, the README has the `CREATE USER` / `GRANT` snippet. With the Docker `postgres:15` recipe above, the default `postgres` superuser already has what's needed.
+
+## Install + generate
+
+```bash
+nvm use            # if you use nvm
+npm install        # postinstall hook also pulls the ai-rules submodule
+npm run generate   # generate the Prisma client
+```
+
+## Apply migrations + seed
+
+```bash
+npm run migrate:reset   # wipes + recreates DB, applies all migrations
+npm run seed            # ~100 fake voters via @faker-js/faker
+```
+
+`npm run seed` only runs when `NODE_ENV` is unset or local — it refuses to seed `production` / `qa` / `development`. See `seed/README.md` for how to extend it.
+
+## Run
+
+```bash
+npm run start:dev    # http://localhost:3002 (watch mode)
+```
+
+Health check: `curl http://localhost:3002/v1/health`. Swagger UI: http://localhost:3002/api.
+
+## Talking to a protected endpoint locally
+
+With `S2S_ALLOW_LOCALHOST=true`:
+
+```bash
+curl -X POST http://localhost:3002/v1/people \
+  -H 'Content-Type: application/json' \
+  -d '{"filters": {}, "page": 1, "pageSize": 10}'
+```
+
+Without localhost bypass, generate a Bearer JWT signed with `PEOPLE_API_S2S_SECRET` and send it as `Authorization: Bearer <token>`. `gp-api` is the production caller — its source has the JWT shape if you need a reference.
+
+## Test
+
+```bash
+npm test                                                            # full suite
+npx vitest run src/people/utils/filters.sql.utils.test.ts          # single file
+npm run test:watch                                                  # watch mode
+```
+
+Tests load env from process — there's no `.env.test`. Mock at the boundary; for SQL builders, assert against the rendered `Prisma.Sql`.
+
+## Lint + format
+
+```bash
+npm run lint            # eslint --fix; mutates files — stage your work first
+npm run lint-format     # lint + prettier --write
+```
+
+## Common gotchas
+
+- **`prisma generate` not run** → TS errors complaining about missing types from `@prisma/client`. Run `npm run generate`.
+- **`green` / `public` schema doesn't exist** → first run of `migrate:reset` creates them. If you bypassed Prisma and created the DB by hand, re-run `migrate:reset`.
+- **README says `npm run download` / `npm run load`** → those scripts are not in `package.json` anymore; ingestion happens out of repo. See `docs/data-pipeline.md`.
+- **Submodule directory empty** → `git submodule update --init --recursive` or `npm run ai-rules:update`.
+- **Port 3002 in use** → set `PORT=3003` in `.env`.
+
+## Where to go next
+
+- `CLAUDE.md` — agent + style guide for the repo.
+- `docs/architecture.md` — module shape, HTTP surface, app composition.
+- `docs/data-pipeline.md` — voter data sources, storage, and read pipeline.
+- `ai-rules/README.md` — org-wide review rules and skills (submodule); explains how to invoke critics and use the templates.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "people-api",
       "version": "0.0.1",
+      "hasInstallScript": true,
       "license": "CC0-1.0",
       "dependencies": {
         "@fast-csv/format": "^5.0.5",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "license": "CC0-1.0",
   "scripts": {
-    "postinstall": "git submodule update --init --recursive",
+    "postinstall": "git submodule update --init --recursive || true",
     "ai-rules:update": "git submodule update --remote ai-rules",
     "build": "nest build",
     "test": "vitest run",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "private": true,
   "license": "CC0-1.0",
   "scripts": {
+    "postinstall": "git submodule update --init --recursive",
     "ai-rules:update": "git submodule update --remote ai-rules",
     "build": "nest build",
     "test": "vitest run",


### PR DESCRIPTION
This PR releases people-api to Prod.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are documentation-only plus a `postinstall` hook to initialize the `ai-rules` git submodule, with no runtime code or API behavior changes.
> 
> **Overview**
> **Documentation refresh:** rewrites `CLAUDE.md` to be a short pointer doc and adds new `docs/` pages for `architecture`, `data-pipeline`, and `getting-started`.
> 
> **Dev workflow tweak:** adds a `postinstall` script (`git submodule update --init --recursive`) and corresponding lockfile metadata so the `ai-rules` submodule is pulled automatically after `npm install`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0890edea53aac4c98c009550399f8e27c029afa. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->