### PR TITLE
draft: IAM role for Airflow to manage people-api RDS resources

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,12 +50,21 @@ jobs:
         id: context
         run: |
           case "${{ github.ref_name }}" in
-            develop) echo "environment=dev" >> "$GITHUB_OUTPUT" ;;
-            master) echo "environment=prod" >> "$GITHUB_OUTPUT" ;;
+            develop)
+              echo "environment=dev" >> "$GITHUB_OUTPUT"
+              echo "astro_deployment_id=${{ vars.ASTRO_DEPLOYMENT_ID_DEV }}" >> "$GITHUB_OUTPUT"
+              ;;
+            master)
+              echo "environment=prod" >> "$GITHUB_OUTPUT"
+              echo "astro_deployment_id=${{ vars.ASTRO_DEPLOYMENT_ID_PROD }}" >> "$GITHUB_OUTPUT"
+              ;;
           esac
 
       - name: Deploy
         working-directory: deploy
+        env:
+          ASTRO_WORKSPACE_ID: ${{ vars.ASTRO_WORKSPACE_ID }}
+          ASTRO_DEPLOYMENT_ID: ${{ steps.context.outputs.astro_deployment_id }}
         run: ./deploy.sh ${{ steps.context.outputs.environment }}
 
       - name: Notify Slack on Success

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Deploy
         working-directory: deploy
         env:
-          ASTRO_ASSUME_ROLE_EXTERNAL_ID: ${{ steps.context.outputs.environment == 'prod' && secrets.ASTRO_ASSUME_ROLE_EXTERNAL_ID_PROD || secrets.ASTRO_ASSUME_ROLE_EXTERNAL_ID_DEV }}
+          ASTRO_ASSUME_ROLE_EXTERNAL_ID: ${{ steps.context.outputs.environment == 'prod' && vars.ASTRO_ASSUME_ROLE_EXTERNAL_ID_PROD || vars.ASTRO_ASSUME_ROLE_EXTERNAL_ID_DEV }}
         run: ./deploy.sh ${{ steps.context.outputs.environment }}
 
       - name: Notify Slack on Success

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ permissions:
 
 env:
   AWS_REGION: us-west-2
-  IMAGE_URI: 333022194791.dkr.ecr.us-west-2.amazonaws.com/people-api:${{ github.sha }}
+  IMAGE_URI: ${{ vars.AWS_ACCOUNT_ID }}.dkr.ecr.us-west-2.amazonaws.com/people-api:${{ github.sha }}
 
 jobs:
   deploy:
@@ -28,7 +28,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v5
         with:
-          role-to-assume: arn:aws:iam::333022194791:role/github-actions-pulumi-deploy
+          role-to-assume: arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/github-actions-pulumi-deploy
           aws-region: us-west-2
 
       - name: Login to Amazon ECR

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ permissions:
 
 env:
   AWS_REGION: us-west-2
-  IMAGE_URI: ${{ vars.AWS_ACCOUNT_ID }}.dkr.ecr.us-west-2.amazonaws.com/people-api:${{ github.sha }}
+  IMAGE_URI: 333022194791.dkr.ecr.us-west-2.amazonaws.com/people-api:${{ github.sha }}
 
 jobs:
   deploy:
@@ -28,7 +28,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v5
         with:
-          role-to-assume: arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/github-actions-pulumi-deploy
+          role-to-assume: arn:aws:iam::333022194791:role/github-actions-pulumi-deploy
           aws-region: us-west-2
 
       - name: Login to Amazon ECR
@@ -56,8 +56,6 @@ jobs:
 
       - name: Deploy
         working-directory: deploy
-        env:
-          AWS_ACCOUNT_ID: ${{ vars.AWS_ACCOUNT_ID }}
         run: ./deploy.sh ${{ steps.context.outputs.environment }}
 
       - name: Notify Slack on Success

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,6 +56,8 @@ jobs:
 
       - name: Deploy
         working-directory: deploy
+        env:
+          AWS_ACCOUNT_ID: ${{ vars.AWS_ACCOUNT_ID }}
         run: ./deploy.sh ${{ steps.context.outputs.environment }}
 
       - name: Notify Slack on Success

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,21 +50,14 @@ jobs:
         id: context
         run: |
           case "${{ github.ref_name }}" in
-            develop)
-              echo "environment=dev" >> "$GITHUB_OUTPUT"
-              echo "astro_deployment_id=${{ vars.ASTRO_DEPLOYMENT_ID_DEV }}" >> "$GITHUB_OUTPUT"
-              ;;
-            master)
-              echo "environment=prod" >> "$GITHUB_OUTPUT"
-              echo "astro_deployment_id=${{ vars.ASTRO_DEPLOYMENT_ID_PROD }}" >> "$GITHUB_OUTPUT"
-              ;;
+            develop) echo "environment=dev" >> "$GITHUB_OUTPUT" ;;
+            master) echo "environment=prod" >> "$GITHUB_OUTPUT" ;;
           esac
 
       - name: Deploy
         working-directory: deploy
         env:
-          ASTRO_WORKSPACE_ID: ${{ vars.ASTRO_WORKSPACE_ID }}
-          ASTRO_DEPLOYMENT_ID: ${{ steps.context.outputs.astro_deployment_id }}
+          ASTRO_ASSUME_ROLE_EXTERNAL_ID: ${{ steps.context.outputs.environment == 'prod' && secrets.ASTRO_ASSUME_ROLE_EXTERNAL_ID_PROD || secrets.ASTRO_ASSUME_ROLE_EXTERNAL_ID_DEV }}
         run: ./deploy.sh ${{ steps.context.outputs.environment }}
 
       - name: Notify Slack on Success

--- a/deploy/components/rds-admin-role.ts
+++ b/deploy/components/rds-admin-role.ts
@@ -4,6 +4,15 @@ import * as aws from '@pulumi/aws'
 const ACCOUNT_ID = '333022194791'
 const REGION = 'us-west-2'
 
+// Astronomer-managed workload-identity roles, one per Astro deployment.
+// Airflow pods already assume these via IRSA on Astronomer's EKS cluster;
+// we trust them here so DAGs can chain into our account via sts:AssumeRole.
+// Find these in the Astro UI under Deployment > Details > Workload Identity.
+const ASTRO_WORKLOAD_IDENTITY = {
+  dev: 'arn:aws:iam::111928029897:role/astro-galactian-element-5125',
+  prod: 'arn:aws:iam::111928029897:role/TODO-PROD-WORKLOAD-IDENTITY',
+}
+
 const namedResources = [
   `arn:aws:rds:${REGION}:${ACCOUNT_ID}:cluster:gp-people-db-20*`,
   `arn:aws:rds:${REGION}:${ACCOUNT_ID}:db:gp-people-db-20*`,
@@ -12,28 +21,22 @@ const namedResources = [
 
 type Args = {
   environment: 'dev' | 'prod'
-  astroWorkspaceId: string
-  astroDeploymentId: string
+  externalId: string
 }
 
-export const createRdsAdminRole = ({
-  environment,
-  astroWorkspaceId,
-  astroDeploymentId,
-}: Args) => {
+export const createRdsAdminRole = ({ environment, externalId }: Args) => {
   const assumeRolePolicy = pulumi.jsonStringify({
     Version: '2012-10-17',
     Statement: [
       {
         Effect: 'Allow',
         Principal: {
-          Federated: `arn:aws:iam::${ACCOUNT_ID}:oidc-provider/auth.astronomer.io/`,
+          AWS: ASTRO_WORKLOAD_IDENTITY[environment],
         },
-        Action: 'sts:AssumeRoleWithWebIdentity',
+        Action: 'sts:AssumeRole',
         Condition: {
           StringEquals: {
-            'auth.astronomer.io:aud': 'sts.amazonaws.com',
-            'auth.astronomer.io:sub': `astro|${astroWorkspaceId}|${astroDeploymentId}`,
+            'sts:ExternalId': externalId,
           },
         },
       },

--- a/deploy/components/rds-admin-role.ts
+++ b/deploy/components/rds-admin-role.ts
@@ -5,9 +5,9 @@ const ACCOUNT_ID = '333022194791'
 const REGION = 'us-west-2'
 
 const namedResources = [
-  `arn:aws:rds:${REGION}:${ACCOUNT_ID}:cluster:gp-*-db-20*`,
-  `arn:aws:rds:${REGION}:${ACCOUNT_ID}:db:gp-*-db-20*`,
-  `arn:aws:rds:${REGION}:${ACCOUNT_ID}:cluster-pg:gp-*-db-20*`,
+  `arn:aws:rds:${REGION}:${ACCOUNT_ID}:cluster:gp-people-db-20*`,
+  `arn:aws:rds:${REGION}:${ACCOUNT_ID}:db:gp-people-db-20*`,
+  `arn:aws:rds:${REGION}:${ACCOUNT_ID}:cluster-pg:gp-people-db-20*`,
 ]
 
 type Args = {

--- a/deploy/components/rds-admin-role.ts
+++ b/deploy/components/rds-admin-role.ts
@@ -1,27 +1,35 @@
 import * as pulumi from '@pulumi/pulumi'
 import * as aws from '@pulumi/aws'
 
+const ACCOUNT_ID = '333022194791'
+const REGION = 'us-west-2'
+
+const namedResources = [
+  `arn:aws:rds:${REGION}:${ACCOUNT_ID}:cluster:gp-*-db-20*`,
+  `arn:aws:rds:${REGION}:${ACCOUNT_ID}:db:gp-*-db-20*`,
+  `arn:aws:rds:${REGION}:${ACCOUNT_ID}:cluster-pg:gp-*-db-20*`,
+]
+
 type Args = {
   environment: 'dev' | 'prod'
-  accountId: string
 }
 
-export const createRdsAdminRole = ({ environment, accountId }: Args) => {
+export const createRdsAdminRole = ({ environment }: Args) => {
   const assumeRolePolicy = pulumi.jsonStringify({
     Version: '2012-10-17',
     Statement: [
       {
         Effect: 'Allow',
         Principal: {
-          Federated: `arn:aws:iam::${accountId}:oidc-provider/auth.astronomer.io/`,
+          Federated: `arn:aws:iam::${ACCOUNT_ID}:oidc-provider/auth.astronomer.io/`,
         },
         Action: 'sts:AssumeRoleWithWebIdentity',
         Condition: {
           StringEquals: {
-            'auth.astronomer.io/:aud': 'sts.amazonaws.com',
+            'auth.astronomer.io:aud': 'sts.amazonaws.com',
           },
           StringLike: {
-            'auth.astronomer.io/:sub':
+            'auth.astronomer.io:sub':
               'astro|TODO_WORKSPACE_ID|TODO_DEPLOYMENT_ID',
           },
         },
@@ -33,11 +41,20 @@ export const createRdsAdminRole = ({ environment, accountId }: Args) => {
     Version: '2012-10-17',
     Statement: [
       {
-        Sid: 'RdsLifecycleTagScoped',
+        Sid: 'RdsCreate',
+        Effect: 'Allow',
+        Action: ['rds:CreateDBCluster', 'rds:CreateDBInstance'],
+        Resource: namedResources,
+        Condition: {
+          StringEquals: {
+            'aws:RequestTag/Environment': environment,
+          },
+        },
+      },
+      {
+        Sid: 'RdsModifyAndDelete',
         Effect: 'Allow',
         Action: [
-          'rds:CreateDBCluster',
-          'rds:CreateDBInstance',
           'rds:AddRoleToDBCluster',
           'rds:RemoveRoleFromDBCluster',
           'rds:ModifyDBCluster',
@@ -48,10 +65,9 @@ export const createRdsAdminRole = ({ environment, accountId }: Args) => {
           'rds:DeleteDBInstance',
           'rds:DeleteDBClusterParameterGroup',
         ],
-        Resource: '*',
+        Resource: namedResources,
         Condition: {
-          StringEqualsIfExists: {
-            'aws:RequestTag/Environment': environment,
+          StringEquals: {
             'aws:ResourceTag/Environment': environment,
           },
         },
@@ -60,7 +76,7 @@ export const createRdsAdminRole = ({ environment, accountId }: Args) => {
         Sid: 'LoaderPassRoleForRDS',
         Effect: 'Allow',
         Action: 'iam:PassRole',
-        Resource: `arn:aws:iam::${accountId}:role/rds-s3-import-*`,
+        Resource: `arn:aws:iam::${ACCOUNT_ID}:role/rds-s3-import-*`,
         Condition: {
           StringEquals: {
             'iam:PassedToService': 'rds.amazonaws.com',

--- a/deploy/components/rds-admin-role.ts
+++ b/deploy/components/rds-admin-role.ts
@@ -10,7 +10,7 @@ const REGION = 'us-west-2'
 // Find these in the Astro UI under Deployment > Details > Workload Identity.
 const ASTRO_WORKLOAD_IDENTITY = {
   dev: 'arn:aws:iam::111928029897:role/astro-galactian-element-5125',
-  prod: 'arn:aws:iam::111928029897:role/TODO-PROD-WORKLOAD-IDENTITY',
+  prod: 'arn:aws:iam::111928029897:role/astro-exothermic-astronaut-9119',
 }
 
 const namedResources = [

--- a/deploy/components/rds-admin-role.ts
+++ b/deploy/components/rds-admin-role.ts
@@ -12,9 +12,15 @@ const namedResources = [
 
 type Args = {
   environment: 'dev' | 'prod'
+  astroWorkspaceId: string
+  astroDeploymentId: string
 }
 
-export const createRdsAdminRole = ({ environment }: Args) => {
+export const createRdsAdminRole = ({
+  environment,
+  astroWorkspaceId,
+  astroDeploymentId,
+}: Args) => {
   const assumeRolePolicy = pulumi.jsonStringify({
     Version: '2012-10-17',
     Statement: [
@@ -27,10 +33,7 @@ export const createRdsAdminRole = ({ environment }: Args) => {
         Condition: {
           StringEquals: {
             'auth.astronomer.io:aud': 'sts.amazonaws.com',
-          },
-          StringLike: {
-            'auth.astronomer.io:sub':
-              'astro|TODO_WORKSPACE_ID|TODO_DEPLOYMENT_ID',
+            'auth.astronomer.io:sub': `astro|${astroWorkspaceId}|${astroDeploymentId}`,
           },
         },
       },
@@ -47,12 +50,13 @@ export const createRdsAdminRole = ({ environment }: Args) => {
         Resource: namedResources,
         Condition: {
           StringEquals: {
+            'aws:RequestTag/managedBy': 'dataplatform',
             'aws:RequestTag/Environment': environment,
           },
         },
       },
       {
-        Sid: 'RdsModifyAndDelete',
+        Sid: 'RdsModifyAndSuspend',
         Effect: 'Allow',
         Action: [
           'rds:AddRoleToDBCluster',
@@ -61,13 +65,15 @@ export const createRdsAdminRole = ({ environment }: Args) => {
           'rds:ModifyDBInstance',
           'rds:RebootDBCluster',
           'rds:RebootDBInstance',
-          'rds:DeleteDBCluster',
-          'rds:DeleteDBInstance',
-          'rds:DeleteDBClusterParameterGroup',
+          'rds:StopDBCluster',
+          'rds:StopDBInstance',
+          'rds:StartDBCluster',
+          'rds:StartDBInstance',
         ],
         Resource: namedResources,
         Condition: {
           StringEquals: {
+            'aws:ResourceTag/managedBy': 'dataplatform',
             'aws:ResourceTag/Environment': environment,
           },
         },

--- a/deploy/components/rds-admin-role.ts
+++ b/deploy/components/rds-admin-role.ts
@@ -1,0 +1,89 @@
+import * as pulumi from '@pulumi/pulumi'
+import * as aws from '@pulumi/aws'
+
+type Args = {
+  environment: 'dev' | 'prod'
+  accountId: string
+}
+
+export const createRdsAdminRole = ({ environment, accountId }: Args) => {
+  const assumeRolePolicy = pulumi.jsonStringify({
+    Version: '2012-10-17',
+    Statement: [
+      {
+        Effect: 'Allow',
+        Principal: {
+          Federated: `arn:aws:iam::${accountId}:oidc-provider/auth.astronomer.io/`,
+        },
+        Action: 'sts:AssumeRoleWithWebIdentity',
+        Condition: {
+          StringEquals: {
+            'auth.astronomer.io/:aud': 'sts.amazonaws.com',
+          },
+          StringLike: {
+            'auth.astronomer.io/:sub':
+              'astro|TODO_WORKSPACE_ID|TODO_DEPLOYMENT_ID',
+          },
+        },
+      },
+    ],
+  })
+
+  const policy = pulumi.jsonStringify({
+    Version: '2012-10-17',
+    Statement: [
+      {
+        Sid: 'RdsLifecycleTagScoped',
+        Effect: 'Allow',
+        Action: [
+          'rds:CreateDBCluster',
+          'rds:CreateDBInstance',
+          'rds:AddRoleToDBCluster',
+          'rds:RemoveRoleFromDBCluster',
+          'rds:ModifyDBCluster',
+          'rds:ModifyDBInstance',
+          'rds:RebootDBCluster',
+          'rds:RebootDBInstance',
+          'rds:DeleteDBCluster',
+          'rds:DeleteDBInstance',
+          'rds:DeleteDBClusterParameterGroup',
+        ],
+        Resource: '*',
+        Condition: {
+          StringEqualsIfExists: {
+            'aws:RequestTag/Environment': environment,
+            'aws:ResourceTag/Environment': environment,
+          },
+        },
+      },
+      {
+        Sid: 'LoaderPassRoleForRDS',
+        Effect: 'Allow',
+        Action: 'iam:PassRole',
+        Resource: `arn:aws:iam::${accountId}:role/rds-s3-import-*`,
+        Condition: {
+          StringEquals: {
+            'iam:PassedToService': 'rds.amazonaws.com',
+          },
+        },
+      },
+    ],
+  })
+
+  return new aws.iam.Role('rdsAdminRole', {
+    name: `gp-people-rds-admin-${environment}`,
+    description: `Assumed by Airflow DAGs to provision and manage people-api RDS resources (${environment}).`,
+    assumeRolePolicy,
+    inlinePolicies: [
+      {
+        name: 'rds-admin',
+        policy,
+      },
+    ],
+    tags: {
+      Environment: environment,
+      ManagedBy: 'pulumi',
+      Component: 'rds-admin',
+    },
+  })
+}

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -12,6 +12,11 @@ if [ -z "$IMAGE_URI" ]; then
   exit 1
 fi
 
+if [ -z "$AWS_ACCOUNT_ID" ]; then
+  echo "Error: AWS_ACCOUNT_ID is not set"
+  exit 1
+fi
+
 PULUMI_CONFIG_PASSPHRASE=$(aws ssm get-parameter \
   --name "pulumi-state-config-passphrase" \
   --with-decryption \
@@ -30,6 +35,7 @@ pulumi stack select "organization/people-api/people-api-$env" --create
 pulumi config set aws:region "$AWS_REGION"
 pulumi config set environment "$env"
 pulumi config set imageUri "$IMAGE_URI"
+pulumi config set accountId "$AWS_ACCOUNT_ID"
 pulumi config set --path aws:defaultTags.tags.Environment "$env"
 pulumi config set --path aws:defaultTags.tags.Project people-api
 

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -12,13 +12,8 @@ if [ -z "$IMAGE_URI" ]; then
   exit 1
 fi
 
-if [ -z "$ASTRO_WORKSPACE_ID" ]; then
-  echo "Error: ASTRO_WORKSPACE_ID is not set"
-  exit 1
-fi
-
-if [ -z "$ASTRO_DEPLOYMENT_ID" ]; then
-  echo "Error: ASTRO_DEPLOYMENT_ID is not set"
+if [ -z "$ASTRO_ASSUME_ROLE_EXTERNAL_ID" ]; then
+  echo "Error: ASTRO_ASSUME_ROLE_EXTERNAL_ID is not set"
   exit 1
 fi
 

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -12,6 +12,16 @@ if [ -z "$IMAGE_URI" ]; then
   exit 1
 fi
 
+if [ -z "$ASTRO_WORKSPACE_ID" ]; then
+  echo "Error: ASTRO_WORKSPACE_ID is not set"
+  exit 1
+fi
+
+if [ -z "$ASTRO_DEPLOYMENT_ID" ]; then
+  echo "Error: ASTRO_DEPLOYMENT_ID is not set"
+  exit 1
+fi
+
 PULUMI_CONFIG_PASSPHRASE=$(aws ssm get-parameter \
   --name "pulumi-state-config-passphrase" \
   --with-decryption \

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -12,11 +12,6 @@ if [ -z "$IMAGE_URI" ]; then
   exit 1
 fi
 
-if [ -z "$AWS_ACCOUNT_ID" ]; then
-  echo "Error: AWS_ACCOUNT_ID is not set"
-  exit 1
-fi
-
 PULUMI_CONFIG_PASSPHRASE=$(aws ssm get-parameter \
   --name "pulumi-state-config-passphrase" \
   --with-decryption \
@@ -35,7 +30,6 @@ pulumi stack select "organization/people-api/people-api-$env" --create
 pulumi config set aws:region "$AWS_REGION"
 pulumi config set environment "$env"
 pulumi config set imageUri "$IMAGE_URI"
-pulumi config set accountId "$AWS_ACCOUNT_ID"
 pulumi config set --path aws:defaultTags.tags.Environment "$env"
 pulumi config set --path aws:defaultTags.tags.Project people-api
 

--- a/deploy/index.ts
+++ b/deploy/index.ts
@@ -17,12 +17,9 @@ export = async () => {
   const environment = config.require('environment') as 'dev' | 'prod'
   const imageUri = config.require('imageUri')
 
-  const astroWorkspaceId = process.env.ASTRO_WORKSPACE_ID
-  const astroDeploymentId = process.env.ASTRO_DEPLOYMENT_ID
-  if (!astroWorkspaceId || !astroDeploymentId) {
-    throw new Error(
-      'ASTRO_WORKSPACE_ID and ASTRO_DEPLOYMENT_ID env vars must be set',
-    )
+  const externalId = process.env.ASTRO_ASSUME_ROLE_EXTERNAL_ID
+  if (!externalId) {
+    throw new Error('ASTRO_ASSUME_ROLE_EXTERNAL_ID env var must be set')
   }
 
   const vpcId = 'vpc-0763fa52c32ebcf6a'
@@ -94,11 +91,7 @@ export = async () => {
     prod: ['tf-20250910223305753900000001', 'tf-20250910223305761900000002'],
   })
 
-  createRdsAdminRole({
-    environment,
-    astroWorkspaceId,
-    astroDeploymentId,
-  })
+  createRdsAdminRole({ environment, externalId })
 
   for (let i = 0; i < rdsInstanceIds.length; i++) {
     new aws.rds.ClusterInstance(`rdsInstance-${i}`, {

--- a/deploy/index.ts
+++ b/deploy/index.ts
@@ -1,6 +1,9 @@
 import * as pulumi from '@pulumi/pulumi'
 import * as aws from '@pulumi/aws'
 import { createService } from './components/service'
+import { createRdsAdminRole } from './components/rds-admin-role'
+
+const ACCOUNT_ID = '333022194791'
 
 const extractDbCredentials = (dbUrl: string) => {
   const url = new URL(dbUrl)
@@ -84,6 +87,8 @@ export = async () => {
     dev: ['gp-people-db-dev-1'],
     prod: ['tf-20250910223305753900000001', 'tf-20250910223305761900000002'],
   })
+
+  createRdsAdminRole({ environment, accountId: ACCOUNT_ID })
 
   for (let i = 0; i < rdsInstanceIds.length; i++) {
     new aws.rds.ClusterInstance(`rdsInstance-${i}`, {

--- a/deploy/index.ts
+++ b/deploy/index.ts
@@ -17,6 +17,14 @@ export = async () => {
   const environment = config.require('environment') as 'dev' | 'prod'
   const imageUri = config.require('imageUri')
 
+  const astroWorkspaceId = process.env.ASTRO_WORKSPACE_ID
+  const astroDeploymentId = process.env.ASTRO_DEPLOYMENT_ID
+  if (!astroWorkspaceId || !astroDeploymentId) {
+    throw new Error(
+      'ASTRO_WORKSPACE_ID and ASTRO_DEPLOYMENT_ID env vars must be set',
+    )
+  }
+
   const vpcId = 'vpc-0763fa52c32ebcf6a'
   const hostedZoneId = 'Z10392302OXMPNQLPO07K'
   const vpcSubnetIds = {
@@ -86,7 +94,11 @@ export = async () => {
     prod: ['tf-20250910223305753900000001', 'tf-20250910223305761900000002'],
   })
 
-  createRdsAdminRole({ environment })
+  createRdsAdminRole({
+    environment,
+    astroWorkspaceId,
+    astroDeploymentId,
+  })
 
   for (let i = 0; i < rdsInstanceIds.length; i++) {
     new aws.rds.ClusterInstance(`rdsInstance-${i}`, {

--- a/deploy/index.ts
+++ b/deploy/index.ts
@@ -16,7 +16,6 @@ export = async () => {
 
   const environment = config.require('environment') as 'dev' | 'prod'
   const imageUri = config.require('imageUri')
-  const accountId = config.require('accountId')
 
   const vpcId = 'vpc-0763fa52c32ebcf6a'
   const hostedZoneId = 'Z10392302OXMPNQLPO07K'
@@ -87,7 +86,7 @@ export = async () => {
     prod: ['tf-20250910223305753900000001', 'tf-20250910223305761900000002'],
   })
 
-  createRdsAdminRole({ environment, accountId })
+  createRdsAdminRole({ environment })
 
   for (let i = 0; i < rdsInstanceIds.length; i++) {
     new aws.rds.ClusterInstance(`rdsInstance-${i}`, {
@@ -117,8 +116,8 @@ export = async () => {
       prod: 'people-api.goodparty.org',
     }),
     certificateArn: select({
-      dev: `arn:aws:acm:us-west-2:${accountId}:certificate/71371e83-7e78-4079-a93f-0a341c0080dc`,
-      prod: `arn:aws:acm:us-west-2:${accountId}:certificate/fb247fc9-b03e-42de-86af-f7de15e4ef46`,
+      dev: 'arn:aws:acm:us-west-2:333022194791:certificate/71371e83-7e78-4079-a93f-0a341c0080dc',
+      prod: 'arn:aws:acm:us-west-2:333022194791:certificate/fb247fc9-b03e-42de-86af-f7de15e4ef46',
     }),
     secrets: Object.fromEntries(
       Object.keys(secret).map((key) => [

--- a/deploy/index.ts
+++ b/deploy/index.ts
@@ -117,8 +117,8 @@ export = async () => {
       prod: 'people-api.goodparty.org',
     }),
     certificateArn: select({
-      dev: 'arn:aws:acm:us-west-2:333022194791:certificate/71371e83-7e78-4079-a93f-0a341c0080dc',
-      prod: 'arn:aws:acm:us-west-2:333022194791:certificate/fb247fc9-b03e-42de-86af-f7de15e4ef46',
+      dev: `arn:aws:acm:us-west-2:${accountId}:certificate/71371e83-7e78-4079-a93f-0a341c0080dc`,
+      prod: `arn:aws:acm:us-west-2:${accountId}:certificate/fb247fc9-b03e-42de-86af-f7de15e4ef46`,
     }),
     secrets: Object.fromEntries(
       Object.keys(secret).map((key) => [

--- a/deploy/index.ts
+++ b/deploy/index.ts
@@ -3,8 +3,6 @@ import * as aws from '@pulumi/aws'
 import { createService } from './components/service'
 import { createRdsAdminRole } from './components/rds-admin-role'
 
-const ACCOUNT_ID = '333022194791'
-
 const extractDbCredentials = (dbUrl: string) => {
   const url = new URL(dbUrl)
   const username = url.username
@@ -18,6 +16,7 @@ export = async () => {
 
   const environment = config.require('environment') as 'dev' | 'prod'
   const imageUri = config.require('imageUri')
+  const accountId = config.require('accountId')
 
   const vpcId = 'vpc-0763fa52c32ebcf6a'
   const hostedZoneId = 'Z10392302OXMPNQLPO07K'
@@ -88,7 +87,7 @@ export = async () => {
     prod: ['tf-20250910223305753900000001', 'tf-20250910223305761900000002'],
   })
 
-  createRdsAdminRole({ environment, accountId: ACCOUNT_ID })
+  createRdsAdminRole({ environment, accountId })
 
   for (let i = 0; i < rdsInstanceIds.length; i++) {
     new aws.rds.ClusterInstance(`rdsInstance-${i}`, {


### PR DESCRIPTION
## Summary

Adds an IAM role (`gp-people-rds-admin-{env}`) that Airflow DAGs can assume to provision and manage RDS resources for people-api.

- New file: `deploy/components/rds-admin-role.ts`
- Wired into `deploy/index.ts` for both `dev` and `prod` stacks (separate role per env, tag-scoped)

Permissions are lifted directly from the [Slack thread](https://goodpartyorg.slack.com/archives/C06NQMW4HJQ/p1776453457505059?thread_ts=1776432934.124779&cid=C06NQMW4HJQ) where @dan and @swain worked through what's needed to spin up + tear down an RDS cluster for the voter-data / people-api migration work.

### Inline policy (two statements)

1. **`RdsLifecycleTagScoped`** — `rds:Create*`, `Modify*`, `Reboot*`, `Delete*`, `Add/RemoveRoleToDBCluster`, etc., scoped via `StringEqualsIfExists` on `aws:RequestTag/Environment` + `aws:ResourceTag/Environment`. Per-stack: dev role only authorizes operations on `Environment=dev` resources, prod only on `Environment=prod`.
2. **`LoaderPassRoleForRDS`** — `iam:PassRole` on `arn:aws:iam::333022194791:role/rds-s3-import-*`, restricted to `iam:PassedToService = rds.amazonaws.com`. Lets the DAG attach an S3-import role to the cluster it just created.

### Trust policy

OIDC federation against Astronomer (`auth.astronomer.io`), using `sts:AssumeRoleWithWebIdentity`. The DAG calls boto3 normally and boto3's web-identity provider exchanges an Astronomer-issued token for STS credentials.

## Open questions for people-api owners

These are the reasons this is opened as a draft:

1. **OIDC provider** — I assumed the trust principal `arn:aws:iam::333022194791:oidc-provider/auth.astronomer.io/`. I could not find this provider declared in `people-api`, `gp-api`, or `gp-terraform-dataplatform`. If it isn't already configured in the AWS account, this role won't be assumable until it is. Two options:
   - The provider already exists outside the repos I checked → confirm the ARN and we're done.
   - It doesn't exist yet → it needs to be created. I'd suggest doing that in `gp-terraform-dataplatform` next to the existing Astronomer config rather than here.
2. **`sub` claim scoping** — currently `astro|TODO_WORKSPACE_ID|TODO_DEPLOYMENT_ID`. Needs to be replaced with the actual Astronomer workspace + deployment IDs that should be allowed to assume the role (probably the data-engineering workspace's prod deployment only for the prod role, etc.).
3. **`aud` claim** — I set it to `sts.amazonaws.com`, which is the default audience boto3 uses for `AssumeRoleWithWebIdentity`. Verify against whatever audience Astronomer actually mints into the tokens.
4. **Tag preconditions on existing RDS clusters** — the policy is tag-scoped, but the existing people-api clusters (`gp-people-db-dev`, `gp-people-db-prod`) don't appear to have an `Environment` tag set in `index.ts`. If the goal is for this role to manage the existing clusters (and not just newly-created tagged ones), either add the tags to those resources or rescope the policy by resource ARN.
5. **Breadth of permissions** — `DeleteDBCluster` / `DeleteDBInstance` are included because Dan's flow tears down ephemeral clusters. If the long-term Airflow DAG only ever *creates* clusters (and humans handle deletes), we could drop the destructive actions for the prod role.

## Test plan

- [ ] `npm run lint` passes in CI
- [ ] `npm run build` passes in CI
- [ ] Resolve the OIDC TODOs and `pulumi preview` (dev stack) shows the role being created with the expected trust + inline policy
- [ ] Deploy to dev and confirm an Airflow DAG can `boto3.client('sts').get_caller_identity()` as the role
- [ ] Have the DAG run an end-to-end `CreateDBCluster` → `AddRoleToDBCluster` → `DeleteDBCluster` against a dev-tagged cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)