### PR TITLE
Prod <- Dev

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,12 +50,21 @@ jobs:
         id: context
         run: |
           case "${{ github.ref_name }}" in
-            develop) echo "environment=dev" >> "$GITHUB_OUTPUT" ;;
-            master) echo "environment=prod" >> "$GITHUB_OUTPUT" ;;
+            develop)
+              echo "environment=dev" >> "$GITHUB_OUTPUT"
+              echo "astro_deployment_id=${{ vars.ASTRO_DEPLOYMENT_ID_DEV }}" >> "$GITHUB_OUTPUT"
+              ;;
+            master)
+              echo "environment=prod" >> "$GITHUB_OUTPUT"
+              echo "astro_deployment_id=${{ vars.ASTRO_DEPLOYMENT_ID_PROD }}" >> "$GITHUB_OUTPUT"
+              ;;
           esac
 
       - name: Deploy
         working-directory: deploy
+        env:
+          ASTRO_WORKSPACE_ID: ${{ vars.ASTRO_WORKSPACE_ID }}
+          ASTRO_DEPLOYMENT_ID: ${{ steps.context.outputs.astro_deployment_id }}
         run: ./deploy.sh ${{ steps.context.outputs.environment }}
 
       - name: Notify Slack on Success

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Deploy
         working-directory: deploy
         env:
-          ASTRO_ASSUME_ROLE_EXTERNAL_ID: ${{ steps.context.outputs.environment == 'prod' && secrets.ASTRO_ASSUME_ROLE_EXTERNAL_ID_PROD || secrets.ASTRO_ASSUME_ROLE_EXTERNAL_ID_DEV }}
+          ASTRO_ASSUME_ROLE_EXTERNAL_ID: ${{ steps.context.outputs.environment == 'prod' && vars.ASTRO_ASSUME_ROLE_EXTERNAL_ID_PROD || vars.ASTRO_ASSUME_ROLE_EXTERNAL_ID_DEV }}
         run: ./deploy.sh ${{ steps.context.outputs.environment }}
 
       - name: Notify Slack on Success

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ permissions:
 
 env:
   AWS_REGION: us-west-2
-  IMAGE_URI: 333022194791.dkr.ecr.us-west-2.amazonaws.com/people-api:${{ github.sha }}
+  IMAGE_URI: ${{ vars.AWS_ACCOUNT_ID }}.dkr.ecr.us-west-2.amazonaws.com/people-api:${{ github.sha }}
 
 jobs:
   deploy:
@@ -28,7 +28,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v5
         with:
-          role-to-assume: arn:aws:iam::333022194791:role/github-actions-pulumi-deploy
+          role-to-assume: arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/github-actions-pulumi-deploy
           aws-region: us-west-2
 
       - name: Login to Amazon ECR

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ permissions:
 
 env:
   AWS_REGION: us-west-2
-  IMAGE_URI: ${{ vars.AWS_ACCOUNT_ID }}.dkr.ecr.us-west-2.amazonaws.com/people-api:${{ github.sha }}
+  IMAGE_URI: 333022194791.dkr.ecr.us-west-2.amazonaws.com/people-api:${{ github.sha }}
 
 jobs:
   deploy:
@@ -28,7 +28,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v5
         with:
-          role-to-assume: arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/github-actions-pulumi-deploy
+          role-to-assume: arn:aws:iam::333022194791:role/github-actions-pulumi-deploy
           aws-region: us-west-2
 
       - name: Login to Amazon ECR
@@ -56,8 +56,6 @@ jobs:
 
       - name: Deploy
         working-directory: deploy
-        env:
-          AWS_ACCOUNT_ID: ${{ vars.AWS_ACCOUNT_ID }}
         run: ./deploy.sh ${{ steps.context.outputs.environment }}
 
       - name: Notify Slack on Success

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,6 +56,8 @@ jobs:
 
       - name: Deploy
         working-directory: deploy
+        env:
+          AWS_ACCOUNT_ID: ${{ vars.AWS_ACCOUNT_ID }}
         run: ./deploy.sh ${{ steps.context.outputs.environment }}
 
       - name: Notify Slack on Success

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,21 +50,14 @@ jobs:
         id: context
         run: |
           case "${{ github.ref_name }}" in
-            develop)
-              echo "environment=dev" >> "$GITHUB_OUTPUT"
-              echo "astro_deployment_id=${{ vars.ASTRO_DEPLOYMENT_ID_DEV }}" >> "$GITHUB_OUTPUT"
-              ;;
-            master)
-              echo "environment=prod" >> "$GITHUB_OUTPUT"
-              echo "astro_deployment_id=${{ vars.ASTRO_DEPLOYMENT_ID_PROD }}" >> "$GITHUB_OUTPUT"
-              ;;
+            develop) echo "environment=dev" >> "$GITHUB_OUTPUT" ;;
+            master) echo "environment=prod" >> "$GITHUB_OUTPUT" ;;
           esac
 
       - name: Deploy
         working-directory: deploy
         env:
-          ASTRO_WORKSPACE_ID: ${{ vars.ASTRO_WORKSPACE_ID }}
-          ASTRO_DEPLOYMENT_ID: ${{ steps.context.outputs.astro_deployment_id }}
+          ASTRO_ASSUME_ROLE_EXTERNAL_ID: ${{ steps.context.outputs.environment == 'prod' && secrets.ASTRO_ASSUME_ROLE_EXTERNAL_ID_PROD || secrets.ASTRO_ASSUME_ROLE_EXTERNAL_ID_DEV }}
         run: ./deploy.sh ${{ steps.context.outputs.environment }}
 
       - name: Notify Slack on Success

--- a/deploy/components/rds-admin-role.ts
+++ b/deploy/components/rds-admin-role.ts
@@ -4,6 +4,15 @@ import * as aws from '@pulumi/aws'
 const ACCOUNT_ID = '333022194791'
 const REGION = 'us-west-2'
 
+// Astronomer-managed workload-identity roles, one per Astro deployment.
+// Airflow pods already assume these via IRSA on Astronomer's EKS cluster;
+// we trust them here so DAGs can chain into our account via sts:AssumeRole.
+// Find these in the Astro UI under Deployment > Details > Workload Identity.
+const ASTRO_WORKLOAD_IDENTITY = {
+  dev: 'arn:aws:iam::111928029897:role/astro-galactian-element-5125',
+  prod: 'arn:aws:iam::111928029897:role/TODO-PROD-WORKLOAD-IDENTITY',
+}
+
 const namedResources = [
   `arn:aws:rds:${REGION}:${ACCOUNT_ID}:cluster:gp-people-db-20*`,
   `arn:aws:rds:${REGION}:${ACCOUNT_ID}:db:gp-people-db-20*`,
@@ -12,28 +21,22 @@ const namedResources = [
 
 type Args = {
   environment: 'dev' | 'prod'
-  astroWorkspaceId: string
-  astroDeploymentId: string
+  externalId: string
 }
 
-export const createRdsAdminRole = ({
-  environment,
-  astroWorkspaceId,
-  astroDeploymentId,
-}: Args) => {
+export const createRdsAdminRole = ({ environment, externalId }: Args) => {
   const assumeRolePolicy = pulumi.jsonStringify({
     Version: '2012-10-17',
     Statement: [
       {
         Effect: 'Allow',
         Principal: {
-          Federated: `arn:aws:iam::${ACCOUNT_ID}:oidc-provider/auth.astronomer.io/`,
+          AWS: ASTRO_WORKLOAD_IDENTITY[environment],
         },
-        Action: 'sts:AssumeRoleWithWebIdentity',
+        Action: 'sts:AssumeRole',
         Condition: {
           StringEquals: {
-            'auth.astronomer.io:aud': 'sts.amazonaws.com',
-            'auth.astronomer.io:sub': `astro|${astroWorkspaceId}|${astroDeploymentId}`,
+            'sts:ExternalId': externalId,
           },
         },
       },

--- a/deploy/components/rds-admin-role.ts
+++ b/deploy/components/rds-admin-role.ts
@@ -5,9 +5,9 @@ const ACCOUNT_ID = '333022194791'
 const REGION = 'us-west-2'
 
 const namedResources = [
-  `arn:aws:rds:${REGION}:${ACCOUNT_ID}:cluster:gp-*-db-20*`,
-  `arn:aws:rds:${REGION}:${ACCOUNT_ID}:db:gp-*-db-20*`,
-  `arn:aws:rds:${REGION}:${ACCOUNT_ID}:cluster-pg:gp-*-db-20*`,
+  `arn:aws:rds:${REGION}:${ACCOUNT_ID}:cluster:gp-people-db-20*`,
+  `arn:aws:rds:${REGION}:${ACCOUNT_ID}:db:gp-people-db-20*`,
+  `arn:aws:rds:${REGION}:${ACCOUNT_ID}:cluster-pg:gp-people-db-20*`,
 ]
 
 type Args = {

--- a/deploy/components/rds-admin-role.ts
+++ b/deploy/components/rds-admin-role.ts
@@ -1,27 +1,35 @@
 import * as pulumi from '@pulumi/pulumi'
 import * as aws from '@pulumi/aws'
 
+const ACCOUNT_ID = '333022194791'
+const REGION = 'us-west-2'
+
+const namedResources = [
+  `arn:aws:rds:${REGION}:${ACCOUNT_ID}:cluster:gp-*-db-20*`,
+  `arn:aws:rds:${REGION}:${ACCOUNT_ID}:db:gp-*-db-20*`,
+  `arn:aws:rds:${REGION}:${ACCOUNT_ID}:cluster-pg:gp-*-db-20*`,
+]
+
 type Args = {
   environment: 'dev' | 'prod'
-  accountId: string
 }
 
-export const createRdsAdminRole = ({ environment, accountId }: Args) => {
+export const createRdsAdminRole = ({ environment }: Args) => {
   const assumeRolePolicy = pulumi.jsonStringify({
     Version: '2012-10-17',
     Statement: [
       {
         Effect: 'Allow',
         Principal: {
-          Federated: `arn:aws:iam::${accountId}:oidc-provider/auth.astronomer.io/`,
+          Federated: `arn:aws:iam::${ACCOUNT_ID}:oidc-provider/auth.astronomer.io/`,
         },
         Action: 'sts:AssumeRoleWithWebIdentity',
         Condition: {
           StringEquals: {
-            'auth.astronomer.io/:aud': 'sts.amazonaws.com',
+            'auth.astronomer.io:aud': 'sts.amazonaws.com',
           },
           StringLike: {
-            'auth.astronomer.io/:sub':
+            'auth.astronomer.io:sub':
               'astro|TODO_WORKSPACE_ID|TODO_DEPLOYMENT_ID',
           },
         },
@@ -33,11 +41,20 @@ export const createRdsAdminRole = ({ environment, accountId }: Args) => {
     Version: '2012-10-17',
     Statement: [
       {
-        Sid: 'RdsLifecycleTagScoped',
+        Sid: 'RdsCreate',
+        Effect: 'Allow',
+        Action: ['rds:CreateDBCluster', 'rds:CreateDBInstance'],
+        Resource: namedResources,
+        Condition: {
+          StringEquals: {
+            'aws:RequestTag/Environment': environment,
+          },
+        },
+      },
+      {
+        Sid: 'RdsModifyAndDelete',
         Effect: 'Allow',
         Action: [
-          'rds:CreateDBCluster',
-          'rds:CreateDBInstance',
           'rds:AddRoleToDBCluster',
           'rds:RemoveRoleFromDBCluster',
           'rds:ModifyDBCluster',
@@ -48,10 +65,9 @@ export const createRdsAdminRole = ({ environment, accountId }: Args) => {
           'rds:DeleteDBInstance',
           'rds:DeleteDBClusterParameterGroup',
         ],
-        Resource: '*',
+        Resource: namedResources,
         Condition: {
-          StringEqualsIfExists: {
-            'aws:RequestTag/Environment': environment,
+          StringEquals: {
             'aws:ResourceTag/Environment': environment,
           },
         },
@@ -60,7 +76,7 @@ export const createRdsAdminRole = ({ environment, accountId }: Args) => {
         Sid: 'LoaderPassRoleForRDS',
         Effect: 'Allow',
         Action: 'iam:PassRole',
-        Resource: `arn:aws:iam::${accountId}:role/rds-s3-import-*`,
+        Resource: `arn:aws:iam::${ACCOUNT_ID}:role/rds-s3-import-*`,
         Condition: {
           StringEquals: {
             'iam:PassedToService': 'rds.amazonaws.com',

--- a/deploy/components/rds-admin-role.ts
+++ b/deploy/components/rds-admin-role.ts
@@ -10,7 +10,7 @@ const REGION = 'us-west-2'
 // Find these in the Astro UI under Deployment > Details > Workload Identity.
 const ASTRO_WORKLOAD_IDENTITY = {
   dev: 'arn:aws:iam::111928029897:role/astro-galactian-element-5125',
-  prod: 'arn:aws:iam::111928029897:role/TODO-PROD-WORKLOAD-IDENTITY',
+  prod: 'arn:aws:iam::111928029897:role/astro-exothermic-astronaut-9119',
 }
 
 const namedResources = [

--- a/deploy/components/rds-admin-role.ts
+++ b/deploy/components/rds-admin-role.ts
@@ -12,9 +12,15 @@ const namedResources = [
 
 type Args = {
   environment: 'dev' | 'prod'
+  astroWorkspaceId: string
+  astroDeploymentId: string
 }
 
-export const createRdsAdminRole = ({ environment }: Args) => {
+export const createRdsAdminRole = ({
+  environment,
+  astroWorkspaceId,
+  astroDeploymentId,
+}: Args) => {
   const assumeRolePolicy = pulumi.jsonStringify({
     Version: '2012-10-17',
     Statement: [
@@ -27,10 +33,7 @@ export const createRdsAdminRole = ({ environment }: Args) => {
         Condition: {
           StringEquals: {
             'auth.astronomer.io:aud': 'sts.amazonaws.com',
-          },
-          StringLike: {
-            'auth.astronomer.io:sub':
-              'astro|TODO_WORKSPACE_ID|TODO_DEPLOYMENT_ID',
+            'auth.astronomer.io:sub': `astro|${astroWorkspaceId}|${astroDeploymentId}`,
           },
         },
       },
@@ -47,12 +50,13 @@ export const createRdsAdminRole = ({ environment }: Args) => {
         Resource: namedResources,
         Condition: {
           StringEquals: {
+            'aws:RequestTag/managedBy': 'dataplatform',
             'aws:RequestTag/Environment': environment,
           },
         },
       },
       {
-        Sid: 'RdsModifyAndDelete',
+        Sid: 'RdsModifyAndSuspend',
         Effect: 'Allow',
         Action: [
           'rds:AddRoleToDBCluster',
@@ -61,13 +65,15 @@ export const createRdsAdminRole = ({ environment }: Args) => {
           'rds:ModifyDBInstance',
           'rds:RebootDBCluster',
           'rds:RebootDBInstance',
-          'rds:DeleteDBCluster',
-          'rds:DeleteDBInstance',
-          'rds:DeleteDBClusterParameterGroup',
+          'rds:StopDBCluster',
+          'rds:StopDBInstance',
+          'rds:StartDBCluster',
+          'rds:StartDBInstance',
         ],
         Resource: namedResources,
         Condition: {
           StringEquals: {
+            'aws:ResourceTag/managedBy': 'dataplatform',
             'aws:ResourceTag/Environment': environment,
           },
         },

--- a/deploy/components/rds-admin-role.ts
+++ b/deploy/components/rds-admin-role.ts
@@ -1,0 +1,89 @@
+import * as pulumi from '@pulumi/pulumi'
+import * as aws from '@pulumi/aws'
+
+type Args = {
+  environment: 'dev' | 'prod'
+  accountId: string
+}
+
+export const createRdsAdminRole = ({ environment, accountId }: Args) => {
+  const assumeRolePolicy = pulumi.jsonStringify({
+    Version: '2012-10-17',
+    Statement: [
+      {
+        Effect: 'Allow',
+        Principal: {
+          Federated: `arn:aws:iam::${accountId}:oidc-provider/auth.astronomer.io/`,
+        },
+        Action: 'sts:AssumeRoleWithWebIdentity',
+        Condition: {
+          StringEquals: {
+            'auth.astronomer.io/:aud': 'sts.amazonaws.com',
+          },
+          StringLike: {
+            'auth.astronomer.io/:sub':
+              'astro|TODO_WORKSPACE_ID|TODO_DEPLOYMENT_ID',
+          },
+        },
+      },
+    ],
+  })
+
+  const policy = pulumi.jsonStringify({
+    Version: '2012-10-17',
+    Statement: [
+      {
+        Sid: 'RdsLifecycleTagScoped',
+        Effect: 'Allow',
+        Action: [
+          'rds:CreateDBCluster',
+          'rds:CreateDBInstance',
+          'rds:AddRoleToDBCluster',
+          'rds:RemoveRoleFromDBCluster',
+          'rds:ModifyDBCluster',
+          'rds:ModifyDBInstance',
+          'rds:RebootDBCluster',
+          'rds:RebootDBInstance',
+          'rds:DeleteDBCluster',
+          'rds:DeleteDBInstance',
+          'rds:DeleteDBClusterParameterGroup',
+        ],
+        Resource: '*',
+        Condition: {
+          StringEqualsIfExists: {
+            'aws:RequestTag/Environment': environment,
+            'aws:ResourceTag/Environment': environment,
+          },
+        },
+      },
+      {
+        Sid: 'LoaderPassRoleForRDS',
+        Effect: 'Allow',
+        Action: 'iam:PassRole',
+        Resource: `arn:aws:iam::${accountId}:role/rds-s3-import-*`,
+        Condition: {
+          StringEquals: {
+            'iam:PassedToService': 'rds.amazonaws.com',
+          },
+        },
+      },
+    ],
+  })
+
+  return new aws.iam.Role('rdsAdminRole', {
+    name: `gp-people-rds-admin-${environment}`,
+    description: `Assumed by Airflow DAGs to provision and manage people-api RDS resources (${environment}).`,
+    assumeRolePolicy,
+    inlinePolicies: [
+      {
+        name: 'rds-admin',
+        policy,
+      },
+    ],
+    tags: {
+      Environment: environment,
+      ManagedBy: 'pulumi',
+      Component: 'rds-admin',
+    },
+  })
+}

--- a/deploy/components/service.ts
+++ b/deploy/components/service.ts
@@ -102,7 +102,13 @@ export const createService = ({
     securityGroups: [albSecurityGroup.id],
     subnets: publicSubnetIds,
     enableCrossZoneLoadBalancing: true,
-    idleTimeout: 120,
+    // 5 minutes — large district CSV exports (up to ~1M rows / hundreds of MB)
+    // stream for several minutes on slow consumer connections. The ALB severs
+    // any TCP connection with >idleTimeout seconds between packets, so we
+    // budget room for occasional PG backpressure stalls without dropping the
+    // download. Bytes ordinarily flow continuously, so this is a ceiling, not
+    // an expected wait time.
+    idleTimeout: 300,
   })
 
   const targetGroup = new aws.lb.TargetGroup('targetGroup', {

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -12,6 +12,11 @@ if [ -z "$IMAGE_URI" ]; then
   exit 1
 fi
 
+if [ -z "$AWS_ACCOUNT_ID" ]; then
+  echo "Error: AWS_ACCOUNT_ID is not set"
+  exit 1
+fi
+
 PULUMI_CONFIG_PASSPHRASE=$(aws ssm get-parameter \
   --name "pulumi-state-config-passphrase" \
   --with-decryption \
@@ -30,6 +35,7 @@ pulumi stack select "organization/people-api/people-api-$env" --create
 pulumi config set aws:region "$AWS_REGION"
 pulumi config set environment "$env"
 pulumi config set imageUri "$IMAGE_URI"
+pulumi config set accountId "$AWS_ACCOUNT_ID"
 pulumi config set --path aws:defaultTags.tags.Environment "$env"
 pulumi config set --path aws:defaultTags.tags.Project people-api
 

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -12,13 +12,8 @@ if [ -z "$IMAGE_URI" ]; then
   exit 1
 fi
 
-if [ -z "$ASTRO_WORKSPACE_ID" ]; then
-  echo "Error: ASTRO_WORKSPACE_ID is not set"
-  exit 1
-fi
-
-if [ -z "$ASTRO_DEPLOYMENT_ID" ]; then
-  echo "Error: ASTRO_DEPLOYMENT_ID is not set"
+if [ -z "$ASTRO_ASSUME_ROLE_EXTERNAL_ID" ]; then
+  echo "Error: ASTRO_ASSUME_ROLE_EXTERNAL_ID is not set"
   exit 1
 fi
 

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -12,6 +12,16 @@ if [ -z "$IMAGE_URI" ]; then
   exit 1
 fi
 
+if [ -z "$ASTRO_WORKSPACE_ID" ]; then
+  echo "Error: ASTRO_WORKSPACE_ID is not set"
+  exit 1
+fi
+
+if [ -z "$ASTRO_DEPLOYMENT_ID" ]; then
+  echo "Error: ASTRO_DEPLOYMENT_ID is not set"
+  exit 1
+fi
+
 PULUMI_CONFIG_PASSPHRASE=$(aws ssm get-parameter \
   --name "pulumi-state-config-passphrase" \
   --with-decryption \

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -12,11 +12,6 @@ if [ -z "$IMAGE_URI" ]; then
   exit 1
 fi
 
-if [ -z "$AWS_ACCOUNT_ID" ]; then
-  echo "Error: AWS_ACCOUNT_ID is not set"
-  exit 1
-fi
-
 PULUMI_CONFIG_PASSPHRASE=$(aws ssm get-parameter \
   --name "pulumi-state-config-passphrase" \
   --with-decryption \
@@ -35,7 +30,6 @@ pulumi stack select "organization/people-api/people-api-$env" --create
 pulumi config set aws:region "$AWS_REGION"
 pulumi config set environment "$env"
 pulumi config set imageUri "$IMAGE_URI"
-pulumi config set accountId "$AWS_ACCOUNT_ID"
 pulumi config set --path aws:defaultTags.tags.Environment "$env"
 pulumi config set --path aws:defaultTags.tags.Project people-api
 

--- a/deploy/index.ts
+++ b/deploy/index.ts
@@ -17,12 +17,9 @@ export = async () => {
   const environment = config.require('environment') as 'dev' | 'prod'
   const imageUri = config.require('imageUri')
 
-  const astroWorkspaceId = process.env.ASTRO_WORKSPACE_ID
-  const astroDeploymentId = process.env.ASTRO_DEPLOYMENT_ID
-  if (!astroWorkspaceId || !astroDeploymentId) {
-    throw new Error(
-      'ASTRO_WORKSPACE_ID and ASTRO_DEPLOYMENT_ID env vars must be set',
-    )
+  const externalId = process.env.ASTRO_ASSUME_ROLE_EXTERNAL_ID
+  if (!externalId) {
+    throw new Error('ASTRO_ASSUME_ROLE_EXTERNAL_ID env var must be set')
   }
 
   const vpcId = 'vpc-0763fa52c32ebcf6a'
@@ -94,11 +91,7 @@ export = async () => {
     prod: ['tf-20250910223305753900000001', 'tf-20250910223305761900000002'],
   })
 
-  createRdsAdminRole({
-    environment,
-    astroWorkspaceId,
-    astroDeploymentId,
-  })
+  createRdsAdminRole({ environment, externalId })
 
   for (let i = 0; i < rdsInstanceIds.length; i++) {
     new aws.rds.ClusterInstance(`rdsInstance-${i}`, {

--- a/deploy/index.ts
+++ b/deploy/index.ts
@@ -1,6 +1,9 @@
 import * as pulumi from '@pulumi/pulumi'
 import * as aws from '@pulumi/aws'
 import { createService } from './components/service'
+import { createRdsAdminRole } from './components/rds-admin-role'
+
+const ACCOUNT_ID = '333022194791'
 
 const extractDbCredentials = (dbUrl: string) => {
   const url = new URL(dbUrl)
@@ -84,6 +87,8 @@ export = async () => {
     dev: ['gp-people-db-dev-1'],
     prod: ['tf-20250910223305753900000001', 'tf-20250910223305761900000002'],
   })
+
+  createRdsAdminRole({ environment, accountId: ACCOUNT_ID })
 
   for (let i = 0; i < rdsInstanceIds.length; i++) {
     new aws.rds.ClusterInstance(`rdsInstance-${i}`, {

--- a/deploy/index.ts
+++ b/deploy/index.ts
@@ -17,6 +17,14 @@ export = async () => {
   const environment = config.require('environment') as 'dev' | 'prod'
   const imageUri = config.require('imageUri')
 
+  const astroWorkspaceId = process.env.ASTRO_WORKSPACE_ID
+  const astroDeploymentId = process.env.ASTRO_DEPLOYMENT_ID
+  if (!astroWorkspaceId || !astroDeploymentId) {
+    throw new Error(
+      'ASTRO_WORKSPACE_ID and ASTRO_DEPLOYMENT_ID env vars must be set',
+    )
+  }
+
   const vpcId = 'vpc-0763fa52c32ebcf6a'
   const hostedZoneId = 'Z10392302OXMPNQLPO07K'
   const vpcSubnetIds = {
@@ -86,7 +94,11 @@ export = async () => {
     prod: ['tf-20250910223305753900000001', 'tf-20250910223305761900000002'],
   })
 
-  createRdsAdminRole({ environment })
+  createRdsAdminRole({
+    environment,
+    astroWorkspaceId,
+    astroDeploymentId,
+  })
 
   for (let i = 0; i < rdsInstanceIds.length; i++) {
     new aws.rds.ClusterInstance(`rdsInstance-${i}`, {

--- a/deploy/index.ts
+++ b/deploy/index.ts
@@ -16,7 +16,6 @@ export = async () => {
 
   const environment = config.require('environment') as 'dev' | 'prod'
   const imageUri = config.require('imageUri')
-  const accountId = config.require('accountId')
 
   const vpcId = 'vpc-0763fa52c32ebcf6a'
   const hostedZoneId = 'Z10392302OXMPNQLPO07K'
@@ -87,7 +86,7 @@ export = async () => {
     prod: ['tf-20250910223305753900000001', 'tf-20250910223305761900000002'],
   })
 
-  createRdsAdminRole({ environment, accountId })
+  createRdsAdminRole({ environment })
 
   for (let i = 0; i < rdsInstanceIds.length; i++) {
     new aws.rds.ClusterInstance(`rdsInstance-${i}`, {
@@ -117,8 +116,8 @@ export = async () => {
       prod: 'people-api.goodparty.org',
     }),
     certificateArn: select({
-      dev: `arn:aws:acm:us-west-2:${accountId}:certificate/71371e83-7e78-4079-a93f-0a341c0080dc`,
-      prod: `arn:aws:acm:us-west-2:${accountId}:certificate/fb247fc9-b03e-42de-86af-f7de15e4ef46`,
+      dev: 'arn:aws:acm:us-west-2:333022194791:certificate/71371e83-7e78-4079-a93f-0a341c0080dc',
+      prod: 'arn:aws:acm:us-west-2:333022194791:certificate/fb247fc9-b03e-42de-86af-f7de15e4ef46',
     }),
     secrets: Object.fromEntries(
       Object.keys(secret).map((key) => [

--- a/deploy/index.ts
+++ b/deploy/index.ts
@@ -117,8 +117,8 @@ export = async () => {
       prod: 'people-api.goodparty.org',
     }),
     certificateArn: select({
-      dev: 'arn:aws:acm:us-west-2:333022194791:certificate/71371e83-7e78-4079-a93f-0a341c0080dc',
-      prod: 'arn:aws:acm:us-west-2:333022194791:certificate/fb247fc9-b03e-42de-86af-f7de15e4ef46',
+      dev: `arn:aws:acm:us-west-2:${accountId}:certificate/71371e83-7e78-4079-a93f-0a341c0080dc`,
+      prod: `arn:aws:acm:us-west-2:${accountId}:certificate/fb247fc9-b03e-42de-86af-f7de15e4ef46`,
     }),
     secrets: Object.fromEntries(
       Object.keys(secret).map((key) => [

--- a/deploy/index.ts
+++ b/deploy/index.ts
@@ -3,8 +3,6 @@ import * as aws from '@pulumi/aws'
 import { createService } from './components/service'
 import { createRdsAdminRole } from './components/rds-admin-role'
 
-const ACCOUNT_ID = '333022194791'
-
 const extractDbCredentials = (dbUrl: string) => {
   const url = new URL(dbUrl)
   const username = url.username
@@ -18,6 +16,7 @@ export = async () => {
 
   const environment = config.require('environment') as 'dev' | 'prod'
   const imageUri = config.require('imageUri')
+  const accountId = config.require('accountId')
 
   const vpcId = 'vpc-0763fa52c32ebcf6a'
   const hostedZoneId = 'Z10392302OXMPNQLPO07K'
@@ -88,7 +87,7 @@ export = async () => {
     prod: ['tf-20250910223305753900000001', 'tf-20250910223305761900000002'],
   })
 
-  createRdsAdminRole({ environment, accountId: ACCOUNT_ID })
+  createRdsAdminRole({ environment, accountId })
 
   for (let i = 0; i < rdsInstanceIds.length; i++) {
     new aws.rds.ClusterInstance(`rdsInstance-${i}`, {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "hasInstallScript": true,
       "license": "CC0-1.0",
       "dependencies": {
-        "@fast-csv/format": "^5.0.5",
         "@fastify/cookie": "^11.0.2",
         "@fastify/cors": "^11.0.0",
         "@fastify/helmet": "^13.0.1",
@@ -43,6 +42,8 @@
         "murmurhash": "^2.0.1",
         "nestjs-pino": "^4.4.1",
         "nestjs-zod": "^4.3.1",
+        "pg": "^8.20.0",
+        "pg-copy-streams": "^6.0.6",
         "pino-http": "^10.5.0",
         "prisma": "^6.4.1",
         "prisma-json-types-generator": "^3.6.2",
@@ -64,6 +65,8 @@
         "@types/jsonwebtoken": "^9.0.6",
         "@types/lodash": "^4.17.16",
         "@types/node": "^22.13.9",
+        "@types/pg": "^8.20.0",
+        "@types/pg-copy-streams": "^1.2.5",
         "@typescript-eslint/eslint-plugin": "^8.0.0",
         "@typescript-eslint/parser": "^8.0.0",
         "eslint": "^8.0.0",
@@ -856,18 +859,6 @@
       "engines": {
         "node": ">=18.0.0",
         "npm": ">=9.0.0"
-      }
-    },
-    "node_modules/@fast-csv/format": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@fast-csv/format/-/format-5.0.5.tgz",
-      "integrity": "sha512-0P9SJXXnqKdmuWlLaTelqbrfdgN37Mvrb369J6eNmqL41IEIZQmV4sNM4GgAK2Dz3aH04J0HKGDMJFkYObThTw==",
-      "license": "MIT",
-      "dependencies": {
-        "lodash.escaperegexp": "^4.1.2",
-        "lodash.isboolean": "^3.0.3",
-        "lodash.isfunction": "^3.0.9",
-        "lodash.isnil": "^4.0.0"
       }
     },
     "node_modules/@fastify/accept-negotiator": {
@@ -6662,6 +6653,29 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
+      }
+    },
+    "node_modules/@types/pg-copy-streams": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@types/pg-copy-streams/-/pg-copy-streams-1.2.5.tgz",
+      "integrity": "sha512-7D6/GYW2uHIaVU6S/5omI+6RZnwlZBpLQDZAH83xX1rjxAOK0f6/deKyyUTewxqts145VIGn6XWYz1YGf50G5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/pg": "*"
+      }
+    },
     "node_modules/@types/qs": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
@@ -11088,12 +11102,6 @@
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
       "license": "MIT"
     },
-    "node_modules/lodash.escaperegexp": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
-      "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
-      "license": "MIT"
-    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -11106,22 +11114,10 @@
       "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
       "license": "MIT"
     },
-    "node_modules/lodash.isfunction": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz",
-      "integrity": "sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw==",
-      "license": "MIT"
-    },
     "node_modules/lodash.isinteger": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
       "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
-      "license": "MIT"
-    },
-    "node_modules/lodash.isnil": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.isnil/-/lodash.isnil-4.0.0.tgz",
-      "integrity": "sha512-up2Mzq3545mwVnMhTDMdfoG1OurpA/s5t88JmQX809eH3C8491iu2sfKhTfhQtKY78oPNhiaHJUpT/dUDAAtng==",
       "license": "MIT"
     },
     "node_modules/lodash.isnumber": {
@@ -12061,6 +12057,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obuf": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
+      "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
+      "license": "MIT"
+    },
     "node_modules/obug": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
@@ -12623,6 +12625,104 @@
       "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
       "license": "MIT"
     },
+    "node_modules/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.12.0",
+        "pg-pool": "^3.13.0",
+        "pg-protocol": "^1.13.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.3.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
+      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.12.0.tgz",
+      "integrity": "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-copy-streams": {
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/pg-copy-streams/-/pg-copy-streams-6.0.6.tgz",
+      "integrity": "sha512-Z+Dd2C2NIDTsjyFKmc6a9QLlpM8tjpERx+43RSx0WmL7j3uNChERi3xSvZUL0hWJ1oRUn4S3fhyt3apdSrTyKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "obuf": "^1.1.2"
+      }
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.13.0.tgz",
+      "integrity": "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
+      "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -12842,6 +12942,45 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/prelude-ls": {
@@ -15709,6 +15848,15 @@
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
       }
     },
     "node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "schema": "prisma/schema"
   },
   "dependencies": {
-    "@fast-csv/format": "^5.0.5",
     "@fastify/cookie": "^11.0.2",
     "@fastify/cors": "^11.0.0",
     "@fastify/helmet": "^13.0.1",
@@ -66,6 +65,8 @@
     "murmurhash": "^2.0.1",
     "nestjs-pino": "^4.4.1",
     "nestjs-zod": "^4.3.1",
+    "pg": "^8.20.0",
+    "pg-copy-streams": "^6.0.6",
     "pino-http": "^10.5.0",
     "prisma": "^6.4.1",
     "prisma-json-types-generator": "^3.6.2",
@@ -87,6 +88,8 @@
     "@types/jsonwebtoken": "^9.0.6",
     "@types/lodash": "^4.17.16",
     "@types/node": "^22.13.9",
+    "@types/pg": "^8.20.0",
+    "@types/pg-copy-streams": "^1.2.5",
     "@typescript-eslint/eslint-plugin": "^8.0.0",
     "@typescript-eslint/parser": "^8.0.0",
     "eslint": "^8.0.0",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -6,12 +6,6 @@ import { PeopleModule } from './people/people.module'
 import { loggerModule } from './observability/logging/logger-module'
 
 @Module({
-  imports: [
-    loggerModule,
-    PrismaModule,
-    HealthModule,
-    PeopleModule,
-    AuthModule,
-  ],
+  imports: [loggerModule, PrismaModule, HealthModule, PeopleModule, AuthModule],
 })
 export class AppModule {}

--- a/src/people/people.controller.ts
+++ b/src/people/people.controller.ts
@@ -8,6 +8,7 @@ import {
   StatsDTO,
 } from './people.schema'
 import { PeopleService } from './services/people.service'
+import { PeopleDownloadService } from './services/peopleDownload.service'
 import { StatsService } from './services/stats.service'
 import { FastifyReply } from 'fastify'
 
@@ -15,6 +16,7 @@ import { FastifyReply } from 'fastify'
 export class PeopleController {
   constructor(
     private readonly peopleService: PeopleService,
+    private readonly peopleDownloadService: PeopleDownloadService,
     private readonly statsService: StatsService,
   ) {}
 
@@ -28,9 +30,12 @@ export class PeopleController {
     @Body() dto: DownloadPeopleDTO,
     @Res() res: FastifyReply,
   ) {
-    res.header('Content-Type', 'text/csv')
-    res.header('Content-Disposition', 'attachment; filename="people.csv"')
-    await this.peopleService.streamPeopleCsv(dto, res)
+    // Headers (Content-Type, Content-Disposition) are set inside
+    // `streamPeopleCsv` only after the pg connection is acquired and the
+    // COPY stream is constructed, so any earlier failure can still surface
+    // as a structured 4xx/5xx instead of an `attachment; filename` header
+    // committing the response to a broken download.
+    await this.peopleDownloadService.streamPeopleCsv(dto, res)
   }
 
   @Get('stats')

--- a/src/people/people.module.ts
+++ b/src/people/people.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common'
 import { PeopleController } from './people.controller'
 import { PeopleService } from './services/people.service'
+import { PeopleDownloadService } from './services/peopleDownload.service'
 import { StatsService } from './services/stats.service'
 import { PrismaModule } from 'src/prisma/prisma.module'
 import { SampleService } from './services/sample.service'
@@ -9,6 +10,11 @@ import { DistrictModule } from 'src/district/district.module'
 @Module({
   imports: [PrismaModule, DistrictModule],
   controllers: [PeopleController],
-  providers: [PeopleService, StatsService, SampleService],
+  providers: [
+    PeopleService,
+    PeopleDownloadService,
+    StatsService,
+    SampleService,
+  ],
 })
 export class PeopleModule {}

--- a/src/people/schemas/filters.schema.utils.test.ts
+++ b/src/people/schemas/filters.schema.utils.test.ts
@@ -184,7 +184,9 @@ describe('transformFilters', () => {
 
       const result = transformFilters(filters, mockSchemaShape)
 
-      expect(result.filterOperators.estimatedIncomeAmountInt.operator).toBe('is')
+      expect(result.filterOperators.estimatedIncomeAmountInt.operator).toBe(
+        'is',
+      )
       expect(result.filterOperators.estimatedIncomeAmountInt.value).toBe('null')
     })
 

--- a/src/people/services/people.service.test.ts
+++ b/src/people/services/people.service.test.ts
@@ -1,5 +1,4 @@
 import { NotFoundException } from '@nestjs/common'
-import { PassThrough } from 'stream'
 import { describe, expect, it, beforeEach, vi } from 'vitest'
 import { PeopleService } from './people.service'
 
@@ -202,7 +201,9 @@ describe('PeopleService', () => {
 
   describe('findPerson', () => {
     it('returns person for district path', async () => {
-      mockClient.$queryRaw.mockResolvedValueOnce([makeDbPerson({ id: 'person-ok' })])
+      mockClient.$queryRaw.mockResolvedValueOnce([
+        makeDbPerson({ id: 'person-ok' }),
+      ])
 
       const person = await service.findPerson('person-ok', {
         districtId: '0e5bafca-93a9-86a5-2522-f373979720df',
@@ -236,53 +237,9 @@ describe('PeopleService', () => {
         service.findPerson('person-1', {
           districtId: 'district-wy',
         } as never),
-      ).rejects.toThrow(new NotFoundException('Person with ID person-1 not found'))
-    })
-  })
-
-  describe('streamPeopleCsv', () => {
-    it('streams csv with headers, data rows, and election fields', async () => {
-      mockClient.$queryRaw
-        .mockResolvedValueOnce([makeDbPerson({ id: 'stream-1' })])
-        .mockResolvedValueOnce([])
-
-      const raw = new PassThrough()
-      const chunks: Buffer[] = []
-      raw.on('data', (chunk) => {
-        chunks.push(Buffer.from(chunk))
-      })
-      const ended = new Promise<void>((resolve) => raw.on('end', () => resolve()))
-
-      await service.streamPeopleCsv(
-        {
-          districtId: '0e5bafca-93a9-86a5-2522-f373979720df',
-          filters: { filters: [], filterOperators: {} },
-        } as never,
-        {
-          raw,
-        } as never,
+      ).rejects.toThrow(
+        new NotFoundException('Person with ID person-1 not found'),
       )
-
-      await ended
-      const csv = Buffer.concat(chunks).toString('utf-8')
-      const lines = csv
-        .split('\n')
-        .map((line) => line.trim())
-        .filter((line) => line.length > 0)
-      const header = lines[0].split(',')
-      const data = lines[1].split(',')
-      const electionLocationIdx = header.indexOf('electionLocation')
-      const electionTypeIdx = header.indexOf('electionType')
-      const unquote = (v: string) => v.replace(/^"(.*)"$/, '$1')
-
-      expect(csv).toContain('electionLocation,electionType')
-      expect(csv).toContain('stream-1')
-      expect(csv).toContain('City_Ward')
-      expect(csv).toContain('CHEYENNE CITY WARD 1')
-      expect(electionLocationIdx).toBeGreaterThan(-1)
-      expect(electionTypeIdx).toBeGreaterThan(-1)
-      expect(unquote(data[electionLocationIdx])).toBe('CHEYENNE CITY WARD 1')
-      expect(unquote(data[electionTypeIdx])).toBe('City_Ward')
     })
   })
 })

--- a/src/people/services/people.service.ts
+++ b/src/people/services/people.service.ts
@@ -1,6 +1,5 @@
 import { Prisma } from '@prisma/client'
 import {
-  DownloadPeopleDTO,
   GetPersonQueryDTO,
   ListPeopleDTO,
   SamplePeopleDTO,
@@ -9,10 +8,6 @@ import { createPrismaBase, MODELS } from 'src/prisma/util/prisma.util'
 import { SampleService } from './sample.service'
 
 import { Injectable, NotFoundException } from '@nestjs/common'
-import { buildVoterFiltersSql } from '../utils/filters.sql.utils'
-import { FastifyReply } from 'fastify'
-import { format } from '@fast-csv/format'
-import type { RowMap } from '@fast-csv/format'
 import { DistrictService } from 'src/district/services/district.service'
 import { transformToPersonOutput } from '../utils/transformToPersonOutput.utils'
 import { FilterData } from '../schemas/filters.schema'
@@ -23,29 +18,12 @@ import {
   ExtraSelectedField,
 } from '../people.select'
 import { resolveDistrict } from '../utils/resolveDistrict.utils'
+import { buildVoterWhereSql } from '../utils/buildVoterWhereSql.utils'
 
 export const DATABASE_SCHEMA = 'green'
 
 const VOTER_TABLENAME = 'Voter'
 const DISTRICTVOTER_TABLENAME = 'DistrictVoter'
-
-const getNormalizedPhoneNumber = (phone: string): string | null => {
-  if (!/^\d+$/.test(phone)) {
-    return null
-  }
-
-  if (![11, 10].includes(phone.length)) {
-    return null
-  }
-
-  const digits =
-    phone.length === 11 && phone.startsWith('1') ? phone.slice(1) : phone
-
-  const area = digits.slice(0, 3)
-  const prefix = digits.slice(3, 6)
-  const line = digits.slice(6)
-  return `(${area}) ${prefix}-${line}`
-}
 
 @Injectable()
 export class PeopleService extends createPrismaBase(MODELS.Voter) {
@@ -103,7 +81,7 @@ export class PeopleService extends createPrismaBase(MODELS.Voter) {
       this.client.$queryRaw<Array<BaseDbPerson>>(
         this.buildRawPeopleQuery({
           districtId: effectiveDistrictId,
-          whereClause: this.rawBuildWhere({
+          whereClause: buildVoterWhereSql({
             state,
             districtId: effectiveDistrictId,
             filters,
@@ -131,159 +109,10 @@ export class PeopleService extends createPrismaBase(MODELS.Voter) {
     }
   }
 
-  async streamPeopleCsv(dto: DownloadPeopleDTO, res: FastifyReply) {
-    const { state, useVoterOnlyPath, districtId, districtType, districtName } =
-      await resolveDistrict(this.districtService, dto)
-    const { filters } = dto
-    const effectiveDistrictId = useVoterOnlyPath ? null : districtId
-    const whereClause = this.rawBuildWhere({
-      districtId: effectiveDistrictId,
-      state,
-      filters,
-    })
-
-    const extraFields: ExtraSelectedField[] = [
-      'AnyElection_2017',
-      'AnyElection_2019',
-      'AnyElection_2021',
-      'AnyElection_2023',
-      'AnyElection_2025',
-      'General_2016',
-      'General_2018',
-      'General_2020',
-      'General_2022',
-      'General_2024',
-      'General_2026',
-      'OtherElection_2016',
-      'OtherElection_2018',
-      'OtherElection_2020',
-      'OtherElection_2022',
-      'OtherElection_2024',
-      'OtherElection_2026',
-      'PresidentialPrimary_2016',
-      'PresidentialPrimary_2020',
-      'PresidentialPrimary_2024',
-      'Primary_2016',
-      'Primary_2018',
-      'Primary_2020',
-      'Primary_2022',
-      'Primary_2024',
-      'Primary_2026',
-    ]
-
-    const { columnNames } = buildVoterSelectSql(extraFields)
-
-    type ExportRow = RowMap<string | number | null | undefined>
-    const csvStream = format<ExportRow, ExportRow>({
-      headers: [...columnNames, 'electionLocation', 'electionType'],
-    })
-    csvStream.pipe(res.raw)
-
-    const pageSize = 5000
-    let lastId: string | undefined
-    let aborted = false
-
-    const onClose = () => {
-      aborted = true
-    }
-    res.raw.on('close', onClose)
-
-    try {
-      for (;;) {
-        if (aborted) break
-        const page = await this.client.$queryRaw<
-          Array<Record<string, unknown>>
-        >(
-          this.buildRawPeopleQuery({
-            districtId: effectiveDistrictId,
-            whereClause,
-            take: pageSize,
-            skip: 0,
-            afterId: lastId,
-            extraFields,
-          }),
-        )
-        if (!page.length) break
-
-        type CsvValue = string | number | null | undefined
-        for (const person of page) {
-          if (aborted) break
-          const row: ExportRow = {}
-          for (const key of columnNames) {
-            row[key] = person[key as keyof typeof person] as CsvValue
-          }
-          row.electionLocation = districtName
-          row.electionType = districtType
-
-          const canContinue = csvStream.write(row)
-          if (!canContinue) {
-            await new Promise<void>((resolve) =>
-              csvStream.once('drain', resolve),
-            )
-          }
-        }
-
-        lastId = page[page.length - 1].id as string
-        if (page.length < pageSize) break
-      }
-    } finally {
-      res.raw.off('close', onClose)
-      csvStream.end()
-    }
-  }
-
   async samplePeople(dto: SamplePeopleDTO) {
     return this.sampleService
       .samplePeople(dto)
       .then((people) => people.map(transformToPersonOutput))
-  }
-
-  private rawBuildWhere(args: {
-    state: string
-    districtId?: string | null
-    filters: FilterData
-    search?: string
-  }): Prisma.Sql {
-    const { state, districtId } = args
-
-    const parts: Prisma.Sql[] = []
-    parts.push(
-      Prisma.sql`v."State" = CAST(${state}::text AS "public"."USState")`,
-    )
-    if (districtId) {
-      parts.push(
-        Prisma.sql`dv."State" = CAST(${state}::text AS "public"."USState")`,
-      )
-      parts.push(Prisma.sql`dv."district_id" = ${districtId}::uuid`)
-      parts.push(Prisma.sql`dv."voter_id" IS NOT NULL`)
-    }
-    const search = args.search?.trim()
-    if (search) {
-      const phone = getNormalizedPhoneNumber(search)
-      if (phone) {
-        parts.push(
-          Prisma.sql`(v."VoterTelephones_CellPhoneFormatted" = ${phone} OR v."VoterTelephones_LandlineFormatted" = ${phone})`,
-        )
-      } else {
-        const tokens = search.split(/\s+/).filter(Boolean)
-        if (tokens.length === 1) {
-          parts.push(
-            Prisma.sql`(v."FirstName" = ${tokens[0]} OR v."LastName" = ${tokens[0]})`,
-          )
-        } else if (tokens.length >= 2) {
-          parts.push(
-            Prisma.sql`(v."FirstName" = ${tokens[0]} AND v."LastName" = ${tokens[1]})`,
-          )
-        }
-      }
-    }
-    const voterFiltersSql = buildVoterFiltersSql(args.filters)
-    if (voterFiltersSql) {
-      parts.push(voterFiltersSql)
-    }
-    return parts.length
-      ? Prisma.sql`WHERE ${Prisma.join(parts, ' AND ')}`
-      : Prisma.empty
   }
 
   private async rawCountForDistrict(args: {
@@ -300,7 +129,7 @@ export class PeopleService extends createPrismaBase(MODELS.Voter) {
       return totalConstituents
     }
 
-    const whereClause = this.rawBuildWhere({
+    const whereClause = buildVoterWhereSql({
       state,
       districtId,
       search,
@@ -333,10 +162,9 @@ export class PeopleService extends createPrismaBase(MODELS.Voter) {
     whereClause: Prisma.Sql
     take: number
     skip: number
-    afterId?: string
     extraFields?: ExtraSelectedField[]
   }): Prisma.Sql {
-    const { districtId, whereClause, take, skip, afterId } = args
+    const { districtId, whereClause, take, skip } = args
 
     const selectSql = buildVoterSelectSql(args.extraFields)
     const voterTable = Prisma.raw(`"${DATABASE_SCHEMA}"."${VOTER_TABLENAME}"`)
@@ -347,16 +175,12 @@ export class PeopleService extends createPrismaBase(MODELS.Voter) {
       ? Prisma.sql`JOIN ${dvTable} dv
             ON v."State" = dv."State" AND v."id" = dv."voter_id"`
       : Prisma.empty
-    const cursorClause = afterId
-      ? Prisma.sql` AND v."id" > ${afterId}::uuid`
-      : Prisma.empty
-    const offsetClause = afterId ? Prisma.empty : Prisma.sql` OFFSET ${skip}`
 
     return Prisma.sql`${selectSql.sql}
           FROM ${voterTable} v
           ${joinClause}
-          ${whereClause}${cursorClause}
+          ${whereClause}
           ORDER BY v."id"
-          LIMIT ${take}${offsetClause}`
+          LIMIT ${take} OFFSET ${skip}`
   }
 }

--- a/src/people/services/peopleDownload.service.test.ts
+++ b/src/people/services/peopleDownload.service.test.ts
@@ -1,0 +1,524 @@
+import { Logger } from '@nestjs/common'
+import { PassThrough } from 'stream'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { PeopleDownloadService } from './peopleDownload.service'
+
+const mockRelease = vi.fn()
+const mockPoolEnd = vi.fn()
+const mockClientQuery = vi.fn()
+const mockPoolConnect = vi.fn()
+
+vi.mock('pg', () => {
+  const PoolClass = function () {
+    // @ts-expect-error -- mock constructor
+    this.connect = mockPoolConnect
+    // @ts-expect-error -- mock constructor
+    this.end = mockPoolEnd
+  }
+  return { Pool: PoolClass }
+})
+
+vi.mock('pg-copy-streams', () => ({
+  to: vi.fn((sql: string) => sql),
+}))
+
+const districtServiceMock = {
+  findDistrictById: vi.fn(),
+}
+
+const DISTRICT_UUID = '0e5bafca-93a9-86a5-2522-f373979720df'
+
+const cityWardDistrict = {
+  id: DISTRICT_UUID,
+  type: 'City_Ward',
+  name: 'CHEYENNE CITY WARD 1',
+  state: 'WY',
+}
+
+const stateDistrict = {
+  id: 'district-wy',
+  type: 'State',
+  name: 'WY',
+  state: 'WY',
+}
+
+const escapeLiteralMock = (raw: string) => `'${raw.replace(/'/g, "''")}'`
+
+const setupClient = () => {
+  const client = {
+    query: mockClientQuery,
+    release: mockRelease,
+    escapeLiteral: escapeLiteralMock,
+  }
+  mockPoolConnect.mockResolvedValue(client)
+  return client
+}
+
+type MockRaw = PassThrough & {
+  statusCode?: number
+  headersSent: boolean
+  flushHeaders: ReturnType<typeof vi.fn>
+  setHeader: ReturnType<typeof vi.fn>
+}
+
+type MockReply = Parameters<PeopleDownloadService['streamPeopleCsv']>[1]
+
+const makeRawResponse = (): { res: MockReply; raw: MockRaw } => {
+  const raw = new PassThrough() as unknown as MockRaw
+  raw.headersSent = false
+  // Real Node ServerResponse exposes `flushHeaders` and `setHeader`. The
+  // download service uses both to commit headers to the wire before COPY
+  // produces any rows.
+  raw.flushHeaders = vi.fn(() => {
+    raw.headersSent = true
+  })
+  raw.setHeader = vi.fn()
+  const res = { raw } as unknown as MockReply
+  return { res, raw }
+}
+
+describe('PeopleDownloadService', () => {
+  let service: PeopleDownloadService
+  let copyStream: PassThrough
+
+  beforeEach(() => {
+    process.env.DATABASE_URL = 'postgres://example/test'
+    vi.clearAllMocks()
+    districtServiceMock.findDistrictById.mockReset()
+    districtServiceMock.findDistrictById.mockResolvedValue(cityWardDistrict)
+
+    copyStream = new PassThrough()
+    // The service issues a plain `SET statement_timeout = 0` before the COPY
+    // and then the COPY itself. The plain SET resolves as a regular pg query
+    // result; the COPY call returns a Readable stream via pg-copy-streams.
+    mockClientQuery.mockImplementation((arg: unknown) => {
+      if (typeof arg === 'string' && arg.startsWith('SET ')) {
+        return Promise.resolve({ rows: [], rowCount: 0 })
+      }
+      return copyStream
+    })
+    setupClient()
+
+    service = new PeopleDownloadService(districtServiceMock as never)
+  })
+
+  afterEach(() => {
+    if (!copyStream.destroyed) copyStream.destroy()
+  })
+
+  describe('streamPeopleCsv', () => {
+    it('builds COPY SQL with the voter join, where clause, and election constants', async () => {
+      const { to: copyTo } = await import('pg-copy-streams')
+
+      const { res, raw } = makeRawResponse()
+      const completion = service.streamPeopleCsv(
+        {
+          districtId: DISTRICT_UUID,
+          filters: { filters: [], filterOperators: {} },
+        } as never,
+        res,
+      )
+
+      copyStream.end()
+      raw.destroy()
+
+      await completion
+
+      const sql = vi.mocked(copyTo).mock.calls[0][0] as string
+      expect(sql).toContain('TO STDOUT WITH (FORMAT CSV, HEADER TRUE)')
+      expect(sql).toContain('FROM "green"."Voter" v')
+      expect(sql).toContain('JOIN "green"."DistrictVoter" dv')
+      expect(sql).toContain(`dv."district_id" = '${DISTRICT_UUID}'::uuid`)
+      expect(sql).toContain(
+        `v."State" = CAST('WY'::text AS "public"."USState")`,
+      )
+      expect(sql).toContain(`'CHEYENNE CITY WARD 1' AS "electionLocation"`)
+      expect(sql).toContain(`'City_Ward' AS "electionType"`)
+      expect(sql).toContain('v."LALVOTERID" AS "LALVOTERID"')
+      expect(sql).toContain('v."Primary_2026" AS "Primary_2026"')
+    })
+
+    it('omits the DistrictVoter join for state-only districts', async () => {
+      const { to: copyTo } = await import('pg-copy-streams')
+      districtServiceMock.findDistrictById.mockResolvedValue(stateDistrict)
+
+      const { res, raw } = makeRawResponse()
+      const completion = service.streamPeopleCsv(
+        {
+          districtId: stateDistrict.id,
+          filters: { filters: [], filterOperators: {} },
+        } as never,
+        res,
+      )
+
+      copyStream.end()
+      raw.destroy()
+
+      await completion
+
+      const sql = vi.mocked(copyTo).mock.calls[0][0] as string
+      expect(sql).not.toContain('JOIN "green"."DistrictVoter"')
+      expect(sql).not.toContain('dv."district_id"')
+      expect(sql).toContain(
+        `v."State" = CAST('WY'::text AS "public"."USState")`,
+      )
+    })
+
+    it('inlines filter predicates into the COPY SQL', async () => {
+      const { to: copyTo } = await import('pg-copy-streams')
+
+      const { res, raw } = makeRawResponse()
+      const completion = service.streamPeopleCsv(
+        {
+          districtId: DISTRICT_UUID,
+          filters: {
+            filters: ['hasCellPhone', 'ageInt'],
+            filterOperators: {
+              hasCellPhone: { operator: 'is', value: 'not_null' },
+              ageInt: { operator: 'range', gte: 30, lte: 50 },
+            },
+          },
+        } as never,
+        res,
+      )
+
+      copyStream.end()
+      raw.destroy()
+
+      await completion
+
+      const sql = vi.mocked(copyTo).mock.calls[0][0] as string
+      expect(sql).toContain(
+        'v."VoterTelephones_CellPhoneFormatted" IS NOT NULL',
+      )
+      expect(sql).toContain('v."Age_Int" >= 30')
+      expect(sql).toContain('v."Age_Int" <= 50')
+    })
+
+    it('pipes COPY stream output into res.raw', async () => {
+      const { res, raw } = makeRawResponse()
+      const chunks: Buffer[] = []
+      raw.on('data', (chunk) => chunks.push(Buffer.from(chunk)))
+
+      const completion = service.streamPeopleCsv(
+        {
+          districtId: DISTRICT_UUID,
+          filters: { filters: [], filterOperators: {} },
+        } as never,
+        res,
+      )
+
+      copyStream.write('id,first_name\n')
+      copyStream.write('"abc","Jane"\n')
+      copyStream.end()
+
+      // pipe.end propagates to raw, which fires `finish` then `close`.
+      await completion
+      const out = Buffer.concat(chunks).toString('utf-8')
+      expect(out).toContain('id,first_name')
+      expect(out).toContain('"abc","Jane"')
+    })
+
+    it('releases the pg client when the COPY stream ends', async () => {
+      const { res } = makeRawResponse()
+      const completion = service.streamPeopleCsv(
+        {
+          districtId: DISTRICT_UUID,
+          filters: { filters: [], filterOperators: {} },
+        } as never,
+        res,
+      )
+
+      copyStream.end()
+      await completion
+
+      expect(mockRelease).toHaveBeenCalledTimes(1)
+    })
+
+    it('releases the pg client and propagates an error on COPY failure', async () => {
+      const { res, raw } = makeRawResponse()
+      const completion = service.streamPeopleCsv(
+        {
+          districtId: DISTRICT_UUID,
+          filters: { filters: [], filterOperators: {} },
+        } as never,
+        res,
+      )
+
+      copyStream.destroy(new Error('pg connection lost'))
+
+      await completion
+      expect(mockRelease).toHaveBeenCalledTimes(1)
+      expect(raw.destroyed).toBe(true)
+    })
+
+    it('destroys the COPY stream when the client aborts (res.raw close)', async () => {
+      const { res, raw } = makeRawResponse()
+      const completion = service.streamPeopleCsv(
+        {
+          districtId: DISTRICT_UUID,
+          filters: { filters: [], filterOperators: {} },
+        } as never,
+        res,
+      )
+
+      raw.destroy()
+      await completion
+
+      expect(copyStream.destroyed).toBe(true)
+      expect(mockRelease).toHaveBeenCalledTimes(1)
+    })
+
+    it('throws InternalServerErrorException when the pool cannot connect', async () => {
+      mockPoolConnect.mockRejectedValueOnce(new Error('pool exhausted'))
+
+      const { res } = makeRawResponse()
+
+      await expect(
+        service.streamPeopleCsv(
+          {
+            districtId: DISTRICT_UUID,
+            filters: { filters: [], filterOperators: {} },
+          } as never,
+          res,
+        ),
+      ).rejects.toMatchObject({ status: 500 })
+    })
+
+    it('disables statement_timeout for the COPY session before issuing the COPY', async () => {
+      const { res } = makeRawResponse()
+      const completion = service.streamPeopleCsv(
+        {
+          districtId: DISTRICT_UUID,
+          filters: { filters: [], filterOperators: {} },
+        } as never,
+        res,
+      )
+
+      copyStream.end()
+      await completion
+
+      const queries = mockClientQuery.mock.calls.map((call) => call[0])
+      const setIdx = queries.findIndex(
+        (q) => typeof q === 'string' && q.includes('statement_timeout'),
+      )
+      const copyIdx = queries.findIndex(
+        (q) => typeof q === 'string' && q.startsWith('COPY ('),
+      )
+      expect(setIdx).toBeGreaterThanOrEqual(0)
+      expect(copyIdx).toBeGreaterThan(setIdx)
+      expect(queries[setIdx]).toBe('SET statement_timeout = 0')
+    })
+
+    it('flushes response headers after pool.connect + SET + COPY init, with download headers set first', async () => {
+      const { to: copyTo } = await import('pg-copy-streams')
+
+      const { res, raw } = makeRawResponse()
+
+      const callOrder: string[] = []
+      mockPoolConnect.mockImplementationOnce(async () => {
+        callOrder.push('connect')
+        return {
+          query: mockClientQuery,
+          release: mockRelease,
+          escapeLiteral: escapeLiteralMock,
+        }
+      })
+      mockClientQuery.mockImplementation((arg: unknown) => {
+        if (typeof arg === 'string' && arg.startsWith('SET ')) {
+          callOrder.push('set-timeout')
+          return Promise.resolve({ rows: [], rowCount: 0 })
+        }
+        callOrder.push('copy')
+        return copyStream
+      })
+      raw.setHeader.mockImplementation((name: string) => {
+        callOrder.push(`set-header:${name}`)
+      })
+      raw.flushHeaders.mockImplementationOnce(() => {
+        callOrder.push('flush-headers')
+      })
+
+      const completion = service.streamPeopleCsv(
+        {
+          districtId: DISTRICT_UUID,
+          filters: { filters: [], filterOperators: {} },
+        } as never,
+        res,
+      )
+
+      copyStream.end()
+      await completion
+
+      expect(raw.flushHeaders).toHaveBeenCalledTimes(1)
+      // Required ordering: connect → SET → COPY init → set the download
+      // headers → flush. Headers must land on the wire after we know the
+      // COPY stream is alive, so any earlier failure surfaces as a
+      // structured 5xx instead of a corrupted "attachment" response.
+      const connectIdx = callOrder.indexOf('connect')
+      const setIdx = callOrder.indexOf('set-timeout')
+      const copyIdx = callOrder.indexOf('copy')
+      const contentTypeIdx = callOrder.indexOf('set-header:Content-Type')
+      const dispositionIdx = callOrder.indexOf('set-header:Content-Disposition')
+      const flushIdx = callOrder.indexOf('flush-headers')
+      expect(connectIdx).toBeGreaterThanOrEqual(0)
+      expect(setIdx).toBeGreaterThan(connectIdx)
+      expect(copyIdx).toBeGreaterThan(setIdx)
+      expect(contentTypeIdx).toBeGreaterThan(copyIdx)
+      expect(dispositionIdx).toBeGreaterThan(copyIdx)
+      expect(flushIdx).toBeGreaterThan(contentTypeIdx)
+      expect(flushIdx).toBeGreaterThan(dispositionIdx)
+      expect(vi.mocked(copyTo)).toHaveBeenCalledTimes(1)
+      expect(raw.setHeader).toHaveBeenCalledWith('Content-Type', 'text/csv')
+      expect(raw.setHeader).toHaveBeenCalledWith(
+        'Content-Disposition',
+        'attachment; filename="people.csv"',
+      )
+    })
+
+    it('does not flush response headers when pool.connect fails', async () => {
+      mockPoolConnect.mockRejectedValueOnce(new Error('pool exhausted'))
+
+      const { res, raw } = makeRawResponse()
+
+      await expect(
+        service.streamPeopleCsv(
+          {
+            districtId: DISTRICT_UUID,
+            filters: { filters: [], filterOperators: {} },
+          } as never,
+          res,
+        ),
+      ).rejects.toMatchObject({ status: 500 })
+
+      expect(raw.flushHeaders).not.toHaveBeenCalled()
+    })
+
+    it('does not flush response headers when SET statement_timeout fails', async () => {
+      mockClientQuery.mockImplementationOnce(() =>
+        Promise.reject(new Error('boom')),
+      )
+
+      const { res, raw } = makeRawResponse()
+
+      await expect(
+        service.streamPeopleCsv(
+          {
+            districtId: DISTRICT_UUID,
+            filters: { filters: [], filterOperators: {} },
+          } as never,
+          res,
+        ),
+      ).rejects.toMatchObject({ status: 500 })
+
+      expect(raw.flushHeaders).not.toHaveBeenCalled()
+    })
+
+    it('releases the pg client and throws when the SET statement_timeout query fails', async () => {
+      mockClientQuery.mockImplementationOnce(() =>
+        Promise.reject(new Error('boom')),
+      )
+
+      const { res } = makeRawResponse()
+
+      await expect(
+        service.streamPeopleCsv(
+          {
+            districtId: DISTRICT_UUID,
+            filters: { filters: [], filterOperators: {} },
+          } as never,
+          res,
+        ),
+      ).rejects.toMatchObject({ status: 500 })
+      expect(mockRelease).toHaveBeenCalledTimes(1)
+    })
+
+    it('releases the pg client and throws 500 when COPY init fails synchronously, before any header flush', async () => {
+      // SET statement_timeout succeeds; the COPY query construction throws
+      // synchronously. Without the try/catch around `client.query(copyTo)`
+      // this would leak a pool client and we would have already flushed
+      // response headers by the time the failure surfaced.
+      mockClientQuery.mockImplementation((arg: unknown) => {
+        if (typeof arg === 'string' && arg.startsWith('SET ')) {
+          return Promise.resolve({ rows: [], rowCount: 0 })
+        }
+        throw new Error('copy init blew up')
+      })
+
+      const { res, raw } = makeRawResponse()
+
+      await expect(
+        service.streamPeopleCsv(
+          {
+            districtId: DISTRICT_UUID,
+            filters: { filters: [], filterOperators: {} },
+          } as never,
+          res,
+        ),
+      ).rejects.toMatchObject({ status: 500 })
+
+      expect(mockRelease).toHaveBeenCalledTimes(1)
+      expect(raw.flushHeaders).not.toHaveBeenCalled()
+      expect(raw.setHeader).not.toHaveBeenCalledWith(
+        'Content-Disposition',
+        expect.anything(),
+      )
+    })
+  })
+
+  describe('onApplicationBootstrap', () => {
+    it('pre-warms the pg pool by acquiring and releasing a connection', async () => {
+      mockPoolConnect.mockClear()
+      mockRelease.mockClear()
+
+      service.onApplicationBootstrap()
+
+      // Pre-warm is fire-and-forget; flush microtasks so the .then() runs.
+      await new Promise((resolve) => setImmediate(resolve))
+
+      expect(mockPoolConnect).toHaveBeenCalledTimes(1)
+      expect(mockRelease).toHaveBeenCalledTimes(1)
+    })
+
+    it('swallows pre-warm errors so bootstrap does not crash the app, logging a warning', async () => {
+      mockPoolConnect.mockClear()
+      mockPoolConnect.mockRejectedValueOnce(new Error('cold pool'))
+
+      // Spy on the Nest Logger prototype so we can assert the swallow was
+      // surfaced as a structured warning rather than just silently dropped.
+      const warnSpy = vi
+        .spyOn(Logger.prototype, 'warn')
+        .mockImplementation(() => {})
+
+      // Track unhandledRejection too — if the catch is ever lost, the
+      // promise rejection would propagate up and we'd fail loudly.
+      const unhandled: unknown[] = []
+      const onUnhandled = (err: unknown) => unhandled.push(err)
+      process.on('unhandledRejection', onUnhandled)
+
+      try {
+        service.onApplicationBootstrap()
+
+        await new Promise((resolve) => setImmediate(resolve))
+
+        expect(mockPoolConnect).toHaveBeenCalledTimes(1)
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.objectContaining({ err: expect.any(Error) }),
+          'Pre-warm of pg pool failed',
+        )
+        expect(unhandled).toEqual([])
+      } finally {
+        process.off('unhandledRejection', onUnhandled)
+        warnSpy.mockRestore()
+      }
+    })
+  })
+
+  describe('onModuleDestroy', () => {
+    it('closes the pool', async () => {
+      mockPoolEnd.mockResolvedValue(undefined)
+      await service.onModuleDestroy()
+      expect(mockPoolEnd).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/src/people/services/peopleDownload.service.ts
+++ b/src/people/services/peopleDownload.service.ts
@@ -1,0 +1,259 @@
+import {
+  Injectable,
+  InternalServerErrorException,
+  Logger,
+  OnApplicationBootstrap,
+  OnModuleDestroy,
+} from '@nestjs/common'
+import type { FastifyReply } from 'fastify'
+import { Pool, PoolClient } from 'pg'
+import { CopyToStreamQuery, to as copyTo } from 'pg-copy-streams'
+import { DistrictService } from 'src/district/services/district.service'
+import { DownloadPeopleDTO } from '../people.schema'
+import { buildVoterSelectSql, ExtraSelectedField } from '../people.select'
+import { buildVoterWhereSql } from '../utils/buildVoterWhereSql.utils'
+import { inlinePrismaSql } from '../utils/inlinePrismaSql.utils'
+import { resolveDistrict } from '../utils/resolveDistrict.utils'
+
+const DATABASE_SCHEMA = 'green'
+const VOTER_TABLENAME = 'Voter'
+const DISTRICTVOTER_TABLENAME = 'DistrictVoter'
+
+// Same turnout columns as the previous fast-csv implementation; preserved
+// exactly so the exported CSV schema does not change.
+const EXTRA_FIELDS: ExtraSelectedField[] = [
+  'AnyElection_2017',
+  'AnyElection_2019',
+  'AnyElection_2021',
+  'AnyElection_2023',
+  'AnyElection_2025',
+  'General_2016',
+  'General_2018',
+  'General_2020',
+  'General_2022',
+  'General_2024',
+  'General_2026',
+  'OtherElection_2016',
+  'OtherElection_2018',
+  'OtherElection_2020',
+  'OtherElection_2022',
+  'OtherElection_2024',
+  'OtherElection_2026',
+  'PresidentialPrimary_2016',
+  'PresidentialPrimary_2020',
+  'PresidentialPrimary_2024',
+  'Primary_2016',
+  'Primary_2018',
+  'Primary_2020',
+  'Primary_2022',
+  'Primary_2024',
+  'Primary_2026',
+]
+
+const quoteIdent = (id: string) => `"${id.replace(/"/g, '""')}"`
+
+@Injectable()
+export class PeopleDownloadService
+  implements OnApplicationBootstrap, OnModuleDestroy
+{
+  private readonly logger = new Logger(PeopleDownloadService.name)
+  private readonly pool: Pool
+
+  constructor(private readonly districtService: DistrictService) {
+    const databaseUrl = process.env.DATABASE_URL
+    if (!databaseUrl) {
+      throw new Error('DATABASE_URL environment variable is required')
+    }
+    // Each COPY holds one session for the entire download. Cap connections so
+    // CSV downloads cannot crowd out other workloads.
+    //
+    // NOTE: `COPY ... TO STDOUT` requires a session-mode Postgres connection.
+    // It is INCOMPATIBLE with `pgbouncer` in transaction or statement pooling
+    // mode. People-api currently connects directly to Aurora Postgres (see
+    // `deploy/index.ts`), which is session-mode. If a transaction-mode pooler
+    // is ever introduced in front of the DB, this service must bypass it.
+    this.pool = new Pool({ connectionString: databaseUrl, max: 10 })
+  }
+
+  onApplicationBootstrap() {
+    // Pay the cold-connect cost up front so the first user-initiated download
+    // after a deploy / idle period doesn't include 200-500ms of pg handshake
+    // in its TTFB. Fire-and-forget; if it fails the next real request will
+    // retry and surface the error normally. Runs only when Nest finishes
+    // bootstrapping, so unit tests that instantiate the service directly do
+    // not pay this cost or pollute pool-call assertions.
+    this.pool
+      .connect()
+      .then((client) => client.release())
+      .catch((err: unknown) => {
+        const error = err instanceof Error ? err : new Error(String(err))
+        this.logger.warn({ err: error }, 'Pre-warm of pg pool failed')
+      })
+  }
+
+  async onModuleDestroy() {
+    await this.pool.end()
+  }
+
+  async streamPeopleCsv(
+    dto: DownloadPeopleDTO,
+    res: FastifyReply,
+  ): Promise<void> {
+    const { state, useVoterOnlyPath, districtId, districtType, districtName } =
+      await resolveDistrict(this.districtService, dto)
+    const effectiveDistrictId = useVoterOnlyPath ? null : districtId
+
+    let client: PoolClient
+    try {
+      client = await this.pool.connect()
+    } catch (err) {
+      this.logger.error({ err }, 'Failed to acquire pg client for COPY')
+      throw new InternalServerErrorException('Failed to start download')
+    }
+
+    // A 1M-row COPY can run for minutes. Disable any inherited
+    // `statement_timeout` for this session so the export is not killed
+    // mid-stream by a cluster default. Pool clients can be reused, so a
+    // future caller may inherit the relaxed value — every subsequent COPY
+    // also sets it explicitly, and no non-COPY path uses this pool.
+    try {
+      await client.query('SET statement_timeout = 0')
+    } catch (err) {
+      client.release()
+      this.logger.error({ err }, 'Failed to disable statement_timeout for COPY')
+      throw new InternalServerErrorException('Failed to start download')
+    }
+
+    // Build the COPY SQL and start the stream BEFORE committing response
+    // headers. A synchronous failure here (bad filter shape, COPY init
+    // rejected) must release the pool client and surface a structured 5xx
+    // — once headers are flushed the connection becomes a binary download
+    // and we can no longer deliver a JSON error.
+    let copyStream: CopyToStreamQuery
+    try {
+      const sql = this.buildCopySql({
+        client,
+        effectiveDistrictId,
+        state,
+        filters: dto.filters,
+        districtName,
+        districtType,
+      })
+      copyStream = client.query(copyTo(sql))
+    } catch (err) {
+      client.release()
+      this.logger.error({ err }, 'Failed to start COPY query')
+      throw new InternalServerErrorException('Failed to start download')
+    }
+
+    // Commit the response headers to the wire now. Postgres can take many
+    // seconds to plan + return the first batch of a large COPY, and Fastify
+    // would otherwise hold our headers until the first body chunk is
+    // written. Flushing here lets the browser display its native download
+    // notification and lets gp-api forward its `Set-Cookie` handshake to the
+    // client before COPY starts producing bytes. After this point we can no
+    // longer return a structured error; the `copyStream.on('error', ...)`
+    // handler below destroys the socket on failure, which is the correct
+    // behavior for an in-flight streaming response.
+    res.raw.setHeader('Content-Type', 'text/csv')
+    res.raw.setHeader(
+      'Content-Disposition',
+      'attachment; filename="people.csv"',
+    )
+    if (!res.raw.headersSent) {
+      res.raw.flushHeaders()
+    }
+
+    let released = false
+    const release = () => {
+      if (released) return
+      released = true
+      client.release()
+    }
+
+    copyStream.on('end', () => {
+      release()
+    })
+
+    copyStream.on('error', (err: Error) => {
+      this.logger.error({ err }, 'COPY stream error')
+      release()
+      if (!res.raw.headersSent) {
+        res.raw.statusCode = 500
+      }
+      // Headers have likely already been sent for a streaming response, so we
+      // cannot deliver a structured error. Terminate the underlying socket
+      // without propagating the error event (the client will see a truncated
+      // response and we have logged the cause).
+      if (!res.raw.destroyed) {
+        res.raw.destroy()
+      }
+    })
+
+    res.raw.on('close', () => {
+      if (!copyStream.destroyed) {
+        copyStream.destroy()
+      }
+      release()
+    })
+
+    copyStream.pipe(res.raw)
+
+    // Keep the Nest request alive until the response has fully flushed to the
+    // client. Real HTTP responses fire `close` once the socket is done; in
+    // tests / non-socket wrappers `finish` arrives first after `end()`. We
+    // accept either signal.
+    await new Promise<void>((resolve) => {
+      const done = () => resolve()
+      res.raw.once('close', done)
+      res.raw.once('finish', done)
+    })
+  }
+
+  private buildCopySql(args: {
+    client: PoolClient
+    effectiveDistrictId: string | null
+    state: string
+    filters: DownloadPeopleDTO['filters']
+    districtName: string
+    districtType: string
+  }): string {
+    const {
+      client,
+      effectiveDistrictId,
+      state,
+      filters,
+      districtName,
+      districtType,
+    } = args
+
+    const { columnNames } = buildVoterSelectSql(EXTRA_FIELDS)
+
+    const voterCols = columnNames
+      .map((c) => `v.${quoteIdent(c)} AS ${quoteIdent(c)}`)
+      .join(', ')
+    const electionLocationLiteral = client.escapeLiteral(districtName)
+    const electionTypeLiteral = client.escapeLiteral(districtType)
+    const selectList = `SELECT ${voterCols}, ${electionLocationLiteral} AS "electionLocation", ${electionTypeLiteral} AS "electionType"`
+
+    const voterTable = `"${DATABASE_SCHEMA}"."${VOTER_TABLENAME}"`
+    const dvTable = `"${DATABASE_SCHEMA}"."${DISTRICTVOTER_TABLENAME}"`
+    const joinClause = effectiveDistrictId
+      ? `JOIN ${dvTable} dv ON v."State" = dv."State" AND v."id" = dv."voter_id"`
+      : ''
+
+    const whereSql = buildVoterWhereSql({
+      state,
+      districtId: effectiveDistrictId,
+      filters,
+    })
+    const whereClause = inlinePrismaSql(whereSql, client)
+
+    return `COPY (
+      ${selectList}
+      FROM ${voterTable} v
+      ${joinClause}
+      ${whereClause}
+    ) TO STDOUT WITH (FORMAT CSV, HEADER TRUE)`
+  }
+}

--- a/src/people/services/sample.service.test.ts
+++ b/src/people/services/sample.service.test.ts
@@ -133,7 +133,10 @@ describe('SampleService', () => {
   it('retries with a new seed when first sample is underfilled', async () => {
     wireTransactionResults([
       [{ id: 'person-a', State: 'WY' }],
-      [{ id: 'person-a', State: 'WY' }, { id: 'person-b', State: 'WY' }],
+      [
+        { id: 'person-a', State: 'WY' },
+        { id: 'person-b', State: 'WY' },
+      ],
     ])
 
     const result = await service.samplePeople({

--- a/src/people/utils/buildVoterWhereSql.utils.ts
+++ b/src/people/utils/buildVoterWhereSql.utils.ts
@@ -1,0 +1,74 @@
+import { Prisma } from '@prisma/client'
+import { FilterData } from '../schemas/filters.schema'
+import { buildVoterFiltersSql } from './filters.sql.utils'
+
+export const getNormalizedPhoneNumber = (phone: string): string | null => {
+  if (!/^\d+$/.test(phone)) {
+    return null
+  }
+
+  if (![11, 10].includes(phone.length)) {
+    return null
+  }
+
+  const digits =
+    phone.length === 11 && phone.startsWith('1') ? phone.slice(1) : phone
+
+  const area = digits.slice(0, 3)
+  const prefix = digits.slice(3, 6)
+  const line = digits.slice(6)
+  return `(${area}) ${prefix}-${line}`
+}
+
+/**
+ * Build the WHERE clause shared by the people list, count, and CSV-download
+ * SQL. Returns `Prisma.empty` when there are no predicates.
+ *
+ * When `districtId` is set the caller is expected to have joined
+ * `green."DistrictVoter" dv ON v."State" = dv."State" AND v."id" = dv."voter_id"`.
+ */
+export const buildVoterWhereSql = (args: {
+  state: string
+  districtId?: string | null
+  filters: FilterData
+  search?: string
+}): Prisma.Sql => {
+  const { state, districtId } = args
+
+  const parts: Prisma.Sql[] = []
+  parts.push(Prisma.sql`v."State" = CAST(${state}::text AS "public"."USState")`)
+  if (districtId) {
+    parts.push(
+      Prisma.sql`dv."State" = CAST(${state}::text AS "public"."USState")`,
+    )
+    parts.push(Prisma.sql`dv."district_id" = ${districtId}::uuid`)
+    parts.push(Prisma.sql`dv."voter_id" IS NOT NULL`)
+  }
+  const search = args.search?.trim()
+  if (search) {
+    const phone = getNormalizedPhoneNumber(search)
+    if (phone) {
+      parts.push(
+        Prisma.sql`(v."VoterTelephones_CellPhoneFormatted" = ${phone} OR v."VoterTelephones_LandlineFormatted" = ${phone})`,
+      )
+    } else {
+      const tokens = search.split(/\s+/).filter(Boolean)
+      if (tokens.length === 1) {
+        parts.push(
+          Prisma.sql`(v."FirstName" = ${tokens[0]} OR v."LastName" = ${tokens[0]})`,
+        )
+      } else if (tokens.length >= 2) {
+        parts.push(
+          Prisma.sql`(v."FirstName" = ${tokens[0]} AND v."LastName" = ${tokens[1]})`,
+        )
+      }
+    }
+  }
+  const voterFiltersSql = buildVoterFiltersSql(args.filters)
+  if (voterFiltersSql) {
+    parts.push(voterFiltersSql)
+  }
+  return parts.length
+    ? Prisma.sql`WHERE ${Prisma.join(parts, ' AND ')}`
+    : Prisma.empty
+}

--- a/src/people/utils/inlinePrismaSql.utils.test.ts
+++ b/src/people/utils/inlinePrismaSql.utils.test.ts
@@ -1,0 +1,100 @@
+import { Prisma } from '@prisma/client'
+import { describe, expect, it } from 'vitest'
+import { inlinePrismaSql } from './inlinePrismaSql.utils'
+
+const mockClient = {
+  escapeLiteral: (raw: string) => `'${raw.replace(/'/g, "''")}'`,
+}
+
+describe('inlinePrismaSql', () => {
+  it('inlines a plain string value via escapeLiteral', () => {
+    const sql = Prisma.sql`SELECT * FROM t WHERE name = ${'alice'}`
+    expect(inlinePrismaSql(sql, mockClient)).toBe(
+      `SELECT * FROM t WHERE name = 'alice'`,
+    )
+  })
+
+  it('inlines numeric values without quotes', () => {
+    const sql = Prisma.sql`SELECT * FROM t WHERE age = ${42}`
+    expect(inlinePrismaSql(sql, mockClient)).toBe(
+      `SELECT * FROM t WHERE age = 42`,
+    )
+  })
+
+  it('inlines null as NULL', () => {
+    const sql = Prisma.sql`SELECT * FROM t WHERE name = ${null}`
+    expect(inlinePrismaSql(sql, mockClient)).toBe(
+      `SELECT * FROM t WHERE name = NULL`,
+    )
+  })
+
+  it('inlines booleans as TRUE/FALSE', () => {
+    const sql = Prisma.sql`SELECT * FROM t WHERE active = ${true} OR muted = ${false}`
+    expect(inlinePrismaSql(sql, mockClient)).toBe(
+      `SELECT * FROM t WHERE active = TRUE OR muted = FALSE`,
+    )
+  })
+
+  it('handles joined Prisma.Sql fragments (in / array)', () => {
+    const values = ['English', 'Spanish']
+    const sql = Prisma.sql`SELECT * FROM t WHERE lang = ANY(ARRAY[${Prisma.join(
+      values.map((v) => Prisma.sql`${v}`),
+      ', ',
+    )}]::text[])`
+    expect(inlinePrismaSql(sql, mockClient)).toBe(
+      `SELECT * FROM t WHERE lang = ANY(ARRAY['English', 'Spanish']::text[])`,
+    )
+  })
+
+  it('handles integer arrays from Prisma.join', () => {
+    const values = [1, 2, 3]
+    const sql = Prisma.sql`v."Age_Int" = ANY(ARRAY[${Prisma.join(
+      values.map((v) => Prisma.sql`${Number(v)}`),
+      ', ',
+    )}]::integer[])`
+    expect(inlinePrismaSql(sql, mockClient)).toBe(
+      `v."Age_Int" = ANY(ARRAY[1, 2, 3]::integer[])`,
+    )
+  })
+
+  it('escapes single quotes in string values to prevent SQL injection', () => {
+    const malicious = `Robert'); DROP TABLE Students;--`
+    const sql = Prisma.sql`SELECT * FROM t WHERE name = ${malicious}`
+    expect(inlinePrismaSql(sql, mockClient)).toBe(
+      `SELECT * FROM t WHERE name = 'Robert''); DROP TABLE Students;--'`,
+    )
+  })
+
+  it('preserves Prisma.raw fragments (zero values, no quoting)', () => {
+    const sql = Prisma.sql`SELECT v."${Prisma.raw('FirstName')}" FROM t WHERE id = ${'x'}`
+    expect(inlinePrismaSql(sql, mockClient)).toBe(
+      `SELECT v."FirstName" FROM t WHERE id = 'x'`,
+    )
+  })
+
+  it('inlines nested AND clauses joined with Prisma.join', () => {
+    const parts = [
+      Prisma.sql`a = ${1}`,
+      Prisma.sql`b = ${'x'}`,
+      Prisma.sql`c IS NULL`,
+    ]
+    const sql = Prisma.sql`WHERE ${Prisma.join(parts, ' AND ')}`
+    expect(inlinePrismaSql(sql, mockClient)).toBe(
+      `WHERE a = 1 AND b = 'x' AND c IS NULL`,
+    )
+  })
+
+  it('falls back to a safe default escape when no client is provided', () => {
+    const sql = Prisma.sql`SELECT * FROM t WHERE name = ${"O'Brien"}`
+    expect(inlinePrismaSql(sql, null)).toBe(
+      `SELECT * FROM t WHERE name = 'O''Brien'`,
+    )
+  })
+
+  it('throws on non-finite numbers', () => {
+    const sql = Prisma.sql`SELECT ${Number.POSITIVE_INFINITY}`
+    expect(() => inlinePrismaSql(sql, mockClient)).toThrow(
+      /Cannot inline non-finite number/,
+    )
+  })
+})

--- a/src/people/utils/inlinePrismaSql.utils.ts
+++ b/src/people/utils/inlinePrismaSql.utils.ts
@@ -1,0 +1,91 @@
+import type { Prisma } from '@prisma/client'
+import type { PoolClient } from 'pg'
+
+/**
+ * Converts a `Prisma.Sql` parameterized statement into a fully inlined SQL
+ * string suitable for use inside `COPY (...) TO STDOUT`. PostgreSQL does not
+ * accept bind parameters inside `COPY`, so we must embed every value
+ * literally and rely on `pg`'s `escapeLiteral` for SQL-injection safety.
+ *
+ * This depends on `Prisma.Sql` exposing `.strings` and `.values` (stable in
+ * `@prisma/client` 5/6). The `inlinePrismaSql` unit tests will fail loudly
+ * if Prisma changes this contract.
+ *
+ * Pass `null` for `client` when escaping for tests; a minimal escape using
+ * single-quote doubling will be used as a fallback. Production callers must
+ * pass a real `PoolClient` so that the official `pg` escape is used.
+ */
+export function inlinePrismaSql(
+  s: Prisma.Sql,
+  client: Pick<PoolClient, 'escapeLiteral'> | null,
+): string {
+  const escape = (raw: string): string =>
+    client?.escapeLiteral
+      ? client.escapeLiteral(raw)
+      : `'${raw.replace(/'/g, "''")}'`
+
+  const { strings, values } = s
+  let out = ''
+  for (let i = 0; i < strings.length; i++) {
+    out += strings[i]
+    if (i < values.length) {
+      out += formatValue(values[i], escape)
+    }
+  }
+  return out
+}
+
+function formatValue(value: unknown, escape: (raw: string) => string): string {
+  if (value === null || value === undefined) {
+    return 'NULL'
+  }
+  if (typeof value === 'boolean') {
+    return value ? 'TRUE' : 'FALSE'
+  }
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      throw new Error(`Cannot inline non-finite number: ${String(value)}`)
+    }
+    return String(value)
+  }
+  if (typeof value === 'bigint') {
+    return value.toString()
+  }
+  if (value instanceof Date) {
+    return escape(value.toISOString())
+  }
+  if (Buffer.isBuffer(value)) {
+    return `'\\x${value.toString('hex')}'::bytea`
+  }
+  if (Array.isArray(value)) {
+    const items = value.map((v) => formatValue(v, escape)).join(', ')
+    return `ARRAY[${items}]`
+  }
+  if (isPrismaSqlLike(value)) {
+    return inlineNestedSql(value, escape)
+  }
+  return escape(String(value))
+}
+
+function isPrismaSqlLike(
+  value: unknown,
+): value is { strings: readonly string[]; values: readonly unknown[] } {
+  if (typeof value !== 'object' || value === null) return false
+  const v = value as { strings?: unknown; values?: unknown }
+  return Array.isArray(v.strings) && Array.isArray(v.values)
+}
+
+function inlineNestedSql(
+  s: { strings: readonly string[]; values: readonly unknown[] },
+  escape: (raw: string) => string,
+): string {
+  const { strings, values } = s
+  let out = ''
+  for (let i = 0; i < strings.length; i++) {
+    out += strings[i]
+    if (i < values.length) {
+      out += formatValue(values[i], escape)
+    }
+  }
+  return out
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Changes production export path (long DB sessions, inlined COPY SQL) and introduces cross-account IAM with broad RDS management on tagged `gp-people-db` resources.
> 
> **Overview**
> **People CSV exports** are reimplemented: `POST /people/download` now uses a dedicated **`PeopleDownloadService`** that streams via PostgreSQL **`COPY ... TO STDOUT`** (`pg` / `pg-copy-streams`) instead of paginated Prisma queries and **`@fast-csv/format`**. Shared voter **`WHERE`** logic moves to **`buildVoterWhereSql`**, with **`inlinePrismaSql`** to embed filter values into COPY SQL (no bind parameters). The handler defers **`Content-Type` / `Content-Disposition`** until after connect, **`SET statement_timeout = 0`**, and COPY init so setup failures return structured errors; the ALB **`idleTimeout`** rises **120 → 300** seconds to tolerate long downloads.
> 
> **Deploy / data platform:** Pulumi adds **`gp-people-rds-admin-{env}`**, assumable by per-environment **Astro workload-identity** roles with **`sts:ExternalId`** from **`ASTRO_ASSUME_ROLE_EXTERNAL_ID`** (wired in **GitHub Actions** and **`deploy.sh`**). The role grants tag-scoped RDS create/modify/start/stop and **`iam:PassRole`** for RDS S3 import roles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ef7c30684b94c36e3586b9168aca5611e02aeae. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->