### PR TITLE
chore(perf): add scripts/perf/ tooling wrappers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,7 +60,7 @@ pids
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 
 # Performance tooling output (scripts/perf/*.sh + node --cpu-prof / --heap-prof / --prof)
-profiles/
+/profiles/
 *.cpuprofile
 *.heapprofile
 *.heapsnapshot

--- a/.gitignore
+++ b/.gitignore
@@ -59,5 +59,14 @@ pids
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 
+# Performance tooling output (scripts/perf/*.sh + node --cpu-prof / --heap-prof / --prof)
+profiles/
+*.cpuprofile
+*.heapprofile
+*.heapsnapshot
+isolate-*.log
+isolate-*.json
+flamegraph.html
+
 # Other
 devnotes.md

--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -1,0 +1,55 @@
+# scripts/perf/
+
+Performance tooling wrappers. Convenience scripts behind the canonical commands in [`ai-rules/performance-tools.md`](../../ai-rules/performance-tools.md).
+
+These complement (not replace) the existing `perf/` directory and `npm run perf:*` scripts, which use **k6** for richer multi-scenario load tests. Use this directory for quick, single-purpose measurements; reach for `perf/` + k6 when you need a journey-style scenario or per-checkpoint stats.
+
+| Script | What it does | Cookbook section | When to reach for it |
+|---|---|---|---|
+| `bench-endpoint.sh` | Single-endpoint HTTP load test (autocannon) | §1 | Quick "is endpoint X faster?" before/after |
+| `profile-cpu.sh` | V8 CPU profile of any node command (writes `.cpuprofile`) | §3 | "Where is the CPU going?" |
+| `explain.sh` | `EXPLAIN (ANALYZE, BUFFERS, VERBOSE)` against the configured DB | §5 | "Is this query hitting the right index?" |
+
+For the multi-endpoint k6 scenarios already in this repo, see `perf/mixed.ts`, `perf/people-get.ts`, `perf/sample-get.ts`, `perf/stats-get.ts`, and the recorded plans in `perf/query-plans.md`.
+
+## Prereqs
+
+```bash
+brew install hyperfine libpq           # libpq gives you psql
+npm i -g autocannon                    # or run via npx autocannon
+```
+
+## Examples
+
+```bash
+# Quick health check load (defaults: 10 connections, 20s)
+scripts/perf/bench-endpoint.sh /health
+
+# Compare a single endpoint across two commits with hyperfine
+hyperfine --warmup 1 --runs 5 \
+  'git checkout main && scripts/perf/bench-endpoint.sh -c 10 -d 10 /v1/people | tail -1' \
+  'git checkout my-branch && scripts/perf/bench-endpoint.sh -c 10 -d 10 /v1/people | tail -1'
+
+# Profile the perf-local server while exercising it
+# Terminal 1: start with the perf-local env AND CPU profiling
+NODE_OPTIONS='--cpu-prof --cpu-prof-dir=./profiles' npm run start:perf-local
+# Terminal 2:
+scripts/perf/bench-endpoint.sh -c 50 -d 30 /v1/people
+# Then ^C terminal 1 and inspect: npx flamebearer < profiles/CPU.*.cpuprofile
+
+# Profile a one-off script
+scripts/perf/profile-cpu.sh -- npx tsx some-job.ts
+
+# EXPLAIN a slow query (reads DATABASE_URL from .env if not already exported)
+scripts/perf/explain.sh 'SELECT * FROM "Voter" WHERE "State" = '\''CA'\'' LIMIT 10'
+scripts/perf/explain.sh -f perf/some-query.sql
+
+# Record a new query plan into perf/query-plans.md
+scripts/perf/explain.sh -f perf/some-query.sql >> perf/query-plans.md
+```
+
+See the cookbook for the full menu of tools (k6, microbenchmarks, GC tracing, heap profiles, production telemetry).
+
+## Critic tie-in
+
+Per the [performance critic rules](../../ai-rules/performance.md), any PR that claims a performance improvement should include before/after numbers from one of these tools (or production telemetry). Without a measurement, the change is a refactor.

--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -6,23 +6,43 @@ These complement (not replace) the existing `perf/` directory and `npm run perf:
 
 | Script | What it does | Cookbook section | When to reach for it |
 |---|---|---|---|
+| `setup-check.sh` | Audit the local env — what can/can't be measured right now | §11.6 | Always run first |
 | `bench-endpoint.sh` | Single-endpoint HTTP load test (autocannon) | §1 | Quick "is endpoint X faster?" before/after |
 | `profile-cpu.sh` | V8 CPU profile of any node command (writes `.cpuprofile`) | §3 | "Where is the CPU going?" |
 | `explain.sh` | `EXPLAIN (ANALYZE, BUFFERS, VERBOSE)` against the configured DB | §5 | "Is this query hitting the right index?" |
 
 For the multi-endpoint k6 scenarios already in this repo, see `perf/mixed.ts`, `perf/people-get.ts`, `perf/sample-get.ts`, `perf/stats-get.ts`, and the recorded plans in `perf/query-plans.md`.
 
-## Prereqs
+Every script supports `-h` / `--help` and prints its prerequisites at the top of the help block.
+
+## Quick start
 
 ```bash
-brew install hyperfine libpq           # libpq gives you psql
-npm i -g autocannon                    # or run via npx autocannon
+# What's available locally?
+scripts/perf/setup-check.sh
 ```
+
+If `setup-check.sh` is clean, the rest will work. If something is ✗, the script tells you the install command for your platform (or the no-install fallback).
+
+## Prereqs
+
+The scripts try hard not to require global installs:
+
+- **autocannon** — `npx --yes autocannon` fallback is automatic when not installed globally.
+- **psql** — when not on PATH but Postgres is in Docker, `docker exec <container> psql` is used automatically. Override the container with `PG_DOCKER_CONTAINER=<name>`.
+- **hyperfine** — no convenient `npx` equivalent; install if you want statistical comparison runs:
+  ```bash
+  brew install hyperfine        # mac
+  cargo install hyperfine       # linux / cross-platform
+  ```
+- **k6** — for multi-endpoint scenarios (this repo's existing `perf/*.ts`). Install: `brew install k6` (mac) or `apt install k6` (linux, Grafana repo) or `docker run --rm grafana/k6`.
+
+For agents working in a fresh `git worktree`, also see `ai-rules/performance-tools.md` §11.6 — `.env` and the `ai-rules` submodule are common first-time stumbling blocks.
 
 ## Examples
 
 ```bash
-# Quick health check load (defaults: 10 connections, 20s)
+# Quick health check load (defaults: 10 connections, 20s; npx fallback if no global)
 scripts/perf/bench-endpoint.sh /health
 
 # Compare a single endpoint across two commits with hyperfine
@@ -30,17 +50,18 @@ hyperfine --warmup 1 --runs 5 \
   'git checkout main && scripts/perf/bench-endpoint.sh -c 10 -d 10 /v1/people | tail -1' \
   'git checkout my-branch && scripts/perf/bench-endpoint.sh -c 10 -d 10 /v1/people | tail -1'
 
-# Profile the perf-local server while exercising it
-# Terminal 1: start with the perf-local env AND CPU profiling
-NODE_OPTIONS='--cpu-prof --cpu-prof-dir=./profiles' npm run start:perf-local
-# Terminal 2:
-scripts/perf/bench-endpoint.sh -c 50 -d 30 /v1/people
-# Then ^C terminal 1 and inspect: npx flamebearer < profiles/CPU.*.cpuprofile
+# Profile a one-off script (exits naturally)
+scripts/perf/profile-cpu.sh -- node dist/scripts/some-job.js
+scripts/perf/profile-cpu.sh -- tsx some-job.ts
 
-# Profile a one-off script
-scripts/perf/profile-cpu.sh -- npx tsx some-job.ts
+# Profile the running server — note: npm-script / nest-start indirection is NOT supported.
+# Profile the built JS directly:
+scripts/perf/profile-cpu.sh -- node dist/main.js
+# In another terminal: drive load through it, then ^C the server.
+# Open the .cpuprofile in Chrome DevTools (Performance > Load profile)
+# or: npx flamebearer < profiles/CPU.*.cpuprofile
 
-# EXPLAIN a slow query (reads DATABASE_URL from .env if not already exported)
+# EXPLAIN a slow query (auto-uses docker exec if host psql missing)
 scripts/perf/explain.sh 'SELECT * FROM "Voter" WHERE "State" = '\''CA'\'' LIMIT 10'
 scripts/perf/explain.sh -f perf/some-query.sql
 
@@ -53,3 +74,5 @@ See the cookbook for the full menu of tools (k6, microbenchmarks, GC tracing, he
 ## Critic tie-in
 
 Per the [performance critic rules](../../ai-rules/performance.md), any PR that claims a performance improvement should include before/after numbers from one of these tools (or production telemetry). Without a measurement, the change is a refactor.
+
+When the critic itself is an agent with shell access, it should run `setup-check.sh` first, then use any GREEN tool it has the prerequisites for (see the readiness table in `performance-tools.md`). It should never fabricate measurements.

--- a/scripts/perf/bench-endpoint.sh
+++ b/scripts/perf/bench-endpoint.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Quick HTTP benchmark using autocannon.
+# Backs up ai-rules/performance-tools.md §1.
+#
+# Usage:
+#   scripts/perf/bench-endpoint.sh /health
+#   scripts/perf/bench-endpoint.sh -c 50 -d 60 /v1/things
+#   scripts/perf/bench-endpoint.sh -m POST \
+#       -H 'content-type: application/json' \
+#       -b '{"x":1}' /v1/things
+#   PORT=3001 HOST=127.0.0.1 scripts/perf/bench-endpoint.sh /health
+#
+# Env overrides:
+#   PORT   (default 3000)
+#   HOST   (default localhost)
+#   PROTO  (default http)
+#
+# Any extra flags are passed through to autocannon.
+# If no -c / -d are passed, defaults are 10 connections and 20 seconds.
+set -euo pipefail
+
+PORT="${PORT:-3000}"
+HOST="${HOST:-localhost}"
+PROTO="${PROTO:-http}"
+
+if [[ $# -eq 0 || "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  sed -n '2,/^set -/p' "$0" | sed 's/^# \{0,1\}//;/^set -/d'
+  [[ $# -eq 0 ]] && exit 2 || exit 0
+fi
+
+if ! command -v autocannon >/dev/null 2>&1; then
+  echo "✗ autocannon not found. Install: npm i -g autocannon" >&2
+  exit 1
+fi
+
+ARGS=("$@")
+HAS_C=false; HAS_D=false
+for a in "${ARGS[@]}"; do
+  case "$a" in
+    -c|--connections) HAS_C=true ;;
+    -d|--duration)    HAS_D=true ;;
+  esac
+done
+$HAS_C || ARGS=(-c 10 "${ARGS[@]}")
+$HAS_D || ARGS=(-d 20 "${ARGS[@]}")
+
+LAST_IDX=$(( ${#ARGS[@]} - 1 ))
+TARGET="${ARGS[$LAST_IDX]}"
+unset 'ARGS[$LAST_IDX]'
+
+if [[ "$TARGET" =~ ^https?:// ]]; then
+  URL="$TARGET"
+else
+  URL="${PROTO}://${HOST}:${PORT}${TARGET}"
+fi
+
+echo "→ autocannon ${ARGS[*]} $URL"
+exec autocannon "${ARGS[@]}" "$URL"

--- a/scripts/perf/bench-endpoint.sh
+++ b/scripts/perf/bench-endpoint.sh
@@ -87,13 +87,17 @@ for a in "${ARGS[@]}"; do
   if $skip_next; then
     DISPLAY_ARGS+=("<redacted>")
     skip_next=false
-  elif [[ "$a" == "-H" || "$a" == "--header" ]]; then
+  elif [[ "$a" == "-H" || "$a" == "--header" || "$a" == "-b" || "$a" == "--body" ]]; then
     DISPLAY_ARGS+=("$a")
     skip_next=true
   elif [[ "$a" == "-H"?* ]]; then
     DISPLAY_ARGS+=("-H<redacted>")
   elif [[ "$a" == "--header="* ]]; then
     DISPLAY_ARGS+=("--header=<redacted>")
+  elif [[ "$a" == "-b"?* ]]; then
+    DISPLAY_ARGS+=("-b<redacted>")
+  elif [[ "$a" == "--body="* ]]; then
+    DISPLAY_ARGS+=("--body=<redacted>")
   else
     DISPLAY_ARGS+=("$a")
   fi

--- a/scripts/perf/bench-endpoint.sh
+++ b/scripts/perf/bench-endpoint.sh
@@ -57,6 +57,17 @@ $HAS_D || ARGS=(-d 20 "${ARGS[@]}")
 
 LAST_IDX=$(( ${#ARGS[@]} - 1 ))
 TARGET="${ARGS[$LAST_IDX]}"
+
+# Reject flags-only invocations (e.g. `bench-endpoint.sh -c 10 -d 20`):
+# we'd otherwise grab the last flag value (20) as the path and benchmark
+# http://host:port/20, which silently 404s and returns misleading numbers.
+# Valid targets must start with `/` (relative path) or `http(s)://`.
+if [[ ! "$TARGET" =~ ^(/|https?://) ]]; then
+  echo "✗ Last argument must be a path (e.g. /health) or full URL — got: '$TARGET'" >&2
+  echo "  Usage: scripts/perf/bench-endpoint.sh [autocannon-flags...] <path-or-url>" >&2
+  exit 2
+fi
+
 unset 'ARGS[$LAST_IDX]'
 
 if [[ "$TARGET" =~ ^https?:// ]]; then

--- a/scripts/perf/bench-endpoint.sh
+++ b/scripts/perf/bench-endpoint.sh
@@ -2,6 +2,11 @@
 # Quick HTTP benchmark using autocannon.
 # Backs up ai-rules/performance-tools.md §1.
 #
+# Requires: a running HTTP server on the target URL (e.g. `npm run start:dev`).
+# Without that you'll get a 0/0/0 reqs/sec table with one connection error.
+# autocannon is preferred installed globally; this script falls back to
+# `npx --yes autocannon` automatically when it isn't.
+#
 # Usage:
 #   scripts/perf/bench-endpoint.sh /health
 #   scripts/perf/bench-endpoint.sh -c 50 -d 60 /v1/things
@@ -28,9 +33,11 @@ if [[ $# -eq 0 || "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
   [[ $# -eq 0 ]] && exit 2 || exit 0
 fi
 
-if ! command -v autocannon >/dev/null 2>&1; then
-  echo "✗ autocannon not found. Install: npm i -g autocannon" >&2
-  exit 1
+if command -v autocannon >/dev/null 2>&1; then
+  AUTOCANNON=(autocannon)
+else
+  echo "→ autocannon not on PATH; falling back to 'npx --yes autocannon' (first run installs)" >&2
+  AUTOCANNON=(npx --yes autocannon)
 fi
 
 ARGS=("$@")
@@ -54,5 +61,5 @@ else
   URL="${PROTO}://${HOST}:${PORT}${TARGET}"
 fi
 
-echo "→ autocannon ${ARGS[*]} $URL"
-exec autocannon "${ARGS[@]}" "$URL"
+echo "→ ${AUTOCANNON[*]} ${ARGS[*]} $URL"
+exec "${AUTOCANNON[@]}" "${ARGS[@]}" "$URL"

--- a/scripts/perf/bench-endpoint.sh
+++ b/scripts/perf/bench-endpoint.sh
@@ -42,10 +42,14 @@ fi
 
 ARGS=("$@")
 HAS_C=false; HAS_D=false
+# autocannon accepts -c/-d four ways: `-c 50`, `-c50` (joined short),
+# `--connections 50`, `--connections=50`. Match all four so we don't inject
+# a duplicate default — minimist/yargs-parser silently merge duplicates into
+# arrays or pick the last value, either of which breaks the run.
 for a in "${ARGS[@]}"; do
   case "$a" in
-    -c|--connections) HAS_C=true ;;
-    -d|--duration)    HAS_D=true ;;
+    -c|--connections|-c[0-9]*|-c=*|--connections=*) HAS_C=true ;;
+    -d|--duration|-d[0-9]*|-d=*|--duration=*)       HAS_D=true ;;
   esac
 done
 $HAS_C || ARGS=(-c 10 "${ARGS[@]}")

--- a/scripts/perf/bench-endpoint.sh
+++ b/scripts/perf/bench-endpoint.sh
@@ -16,7 +16,7 @@
 #   PORT=3001 HOST=127.0.0.1 scripts/perf/bench-endpoint.sh /health
 #
 # Env overrides:
-#   PORT   (default 3000)
+#   PORT   (default 3002 — people-api dev server)
 #   HOST   (default localhost)
 #   PROTO  (default http)
 #
@@ -24,7 +24,7 @@
 # If no -c / -d are passed, defaults are 10 connections and 20 seconds.
 set -euo pipefail
 
-PORT="${PORT:-3000}"
+PORT="${PORT:-3002}"
 HOST="${HOST:-localhost}"
 PROTO="${PROTO:-http}"
 
@@ -76,5 +76,28 @@ else
   URL="${PROTO}://${HOST}:${PORT}${TARGET}"
 fi
 
-echo "→ ${AUTOCANNON[*]} ${ARGS[*]} $URL"
+# Redact `-H` header values from the printed command line. autocannon
+# headers commonly carry secrets (`-H 'authorization: Bearer <token>'`),
+# which would otherwise land in terminal output, CI logs, and shell
+# history. The actual exec() call below uses the unmodified ARGS, so
+# autocannon still sends the real headers — only the display is redacted.
+DISPLAY_ARGS=()
+skip_next=false
+for a in "${ARGS[@]}"; do
+  if $skip_next; then
+    DISPLAY_ARGS+=("<redacted>")
+    skip_next=false
+  elif [[ "$a" == "-H" || "$a" == "--header" ]]; then
+    DISPLAY_ARGS+=("$a")
+    skip_next=true
+  elif [[ "$a" == "-H"?* ]]; then
+    DISPLAY_ARGS+=("-H<redacted>")
+  elif [[ "$a" == "--header="* ]]; then
+    DISPLAY_ARGS+=("--header=<redacted>")
+  else
+    DISPLAY_ARGS+=("$a")
+  fi
+done
+
+echo "→ ${AUTOCANNON[*]} ${DISPLAY_ARGS[*]} $URL"
 exec "${AUTOCANNON[@]}" "${ARGS[@]}" "$URL"

--- a/scripts/perf/explain.sh
+++ b/scripts/perf/explain.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Run EXPLAIN (ANALYZE, BUFFERS, VERBOSE) on a SQL query using DATABASE_URL.
+# Backs up ai-rules/performance-tools.md §5.
+#
+# Usage:
+#   scripts/perf/explain.sh 'SELECT * FROM "User" WHERE "email" = '\''x@y.com'\'''
+#   scripts/perf/explain.sh -f path/to/query.sql
+#   scripts/perf/explain.sh --format JSON 'SELECT 1'
+#   DATABASE_URL=postgres://... scripts/perf/explain.sh '...'
+#
+# Reads DATABASE_URL from the environment, or extracts it from ./.env if present.
+# WARNING: EXPLAIN ANALYZE *executes* the query. Don't run UPDATE / DELETE
+# without wrapping in BEGIN; ROLLBACK; (psql -1 isn't enough on its own here).
+set -euo pipefail
+
+FORMAT="TEXT"
+QUERY=""
+FILE=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --format) FORMAT="$2"; shift 2 ;;
+    -f|--file) FILE="$2"; shift 2 ;;
+    -h|--help)
+      sed -n '2,/^set -/p' "$0" | sed 's/^# \{0,1\}//;/^set -/d'
+      exit 0 ;;
+    *) QUERY="$1"; shift ;;
+  esac
+done
+
+if [[ -z "${DATABASE_URL:-}" && -f ./.env ]]; then
+  # Extract DATABASE_URL without sourcing the whole .env (avoids $-expansion of secrets).
+  line="$(grep -E '^DATABASE_URL[[:space:]]*=' ./.env | head -1 || true)"
+  if [[ -n "$line" ]]; then
+    val="${line#*=}"
+    val="${val%\"}"; val="${val#\"}"
+    val="${val%\'}"; val="${val#\'}"
+    export DATABASE_URL="$val"
+  fi
+fi
+
+if [[ -z "${DATABASE_URL:-}" ]]; then
+  echo "✗ DATABASE_URL is not set (no ./.env either)." >&2
+  exit 1
+fi
+
+if ! command -v psql >/dev/null 2>&1; then
+  echo "✗ psql not found. Install: brew install libpq && brew link --force libpq" >&2
+  exit 1
+fi
+
+if [[ -n "$FILE" ]]; then
+  QUERY="$(cat "$FILE")"
+fi
+
+if [[ -z "$QUERY" ]]; then
+  echo "✗ No query provided. Pass a query string or -f file.sql" >&2
+  exit 2
+fi
+
+QUERY="${QUERY%;}"
+EXPLAIN="EXPLAIN (ANALYZE, BUFFERS, VERBOSE, FORMAT $FORMAT) $QUERY;"
+
+echo "→ EXPLAIN (ANALYZE, BUFFERS, VERBOSE, FORMAT $FORMAT) <query>"
+echo
+exec psql "$DATABASE_URL" -X -c "$EXPLAIN"

--- a/scripts/perf/explain.sh
+++ b/scripts/perf/explain.sh
@@ -2,13 +2,23 @@
 # Run EXPLAIN (ANALYZE, BUFFERS, VERBOSE) on a SQL query using DATABASE_URL.
 # Backs up ai-rules/performance-tools.md §5.
 #
+# Requires: a Postgres connection. EITHER `psql` on PATH AND a reachable
+# DATABASE_URL, OR a running Postgres docker container reachable via
+# `docker exec` (set PG_DOCKER_CONTAINER if its name isn't goodparty-postgres).
+#
+# DATABASE_URL is looked up in this order:
+#   1. The environment, if already set.
+#   2. ./.env in the current working directory.
+#   3. ../<parent worktree>/.env (i.e. the superproject's .env when this
+#      script runs inside a git worktree without its own .env).
+#
 # Usage:
 #   scripts/perf/explain.sh 'SELECT * FROM "User" WHERE "email" = '\''x@y.com'\'''
 #   scripts/perf/explain.sh -f path/to/query.sql
 #   scripts/perf/explain.sh --format JSON 'SELECT 1'
 #   DATABASE_URL=postgres://... scripts/perf/explain.sh '...'
+#   PG_DOCKER_CONTAINER=my-pg scripts/perf/explain.sh 'SELECT 1'
 #
-# Reads DATABASE_URL from the environment, or extracts it from ./.env if present.
 # WARNING: EXPLAIN ANALYZE *executes* the query. Don't run UPDATE / DELETE
 # without wrapping in BEGIN; ROLLBACK; (psql -1 isn't enough on its own here).
 set -euo pipefail
@@ -28,25 +38,101 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-if [[ -z "${DATABASE_URL:-}" && -f ./.env ]]; then
-  # Extract DATABASE_URL without sourcing the whole .env (avoids $-expansion of secrets).
-  line="$(grep -E '^DATABASE_URL[[:space:]]*=' ./.env | head -1 || true)"
+# --- DATABASE_URL resolution ---
+
+extract_database_url() {
+  # $1 = path to .env file. Echoes the value (no export, no side effects).
+  # Handles: outer quotes (single or double), trailing inline `# comment`.
+  local line val
+  line="$(grep -E '^DATABASE_URL[[:space:]]*=' "$1" | head -1 || true)"
   if [[ -n "$line" ]]; then
     val="${line#*=}"
-    val="${val%\"}"; val="${val#\"}"
-    val="${val%\'}"; val="${val#\'}"
-    export DATABASE_URL="$val"
+    # If the value is double-quoted, take everything up to the closing quote.
+    if [[ "$val" == \"* ]]; then
+      val="${val#\"}"
+      val="${val%%\"*}"
+    elif [[ "$val" == \'* ]]; then
+      val="${val#\'}"
+      val="${val%%\'*}"
+    else
+      # Unquoted: strip trailing whitespace and inline comments.
+      val="${val%%#*}"
+      val="${val%%[[:space:]]*}"
+    fi
+    echo "$val"
+  fi
+}
+
+strip_prisma_params() {
+  # Strip Prisma-specific query parameters that vanilla psql doesn't understand
+  # (schema, connection_limit, pool_timeout, pgbouncer, etc.). Echoes the
+  # cleaned URL — safe to pass to psql.
+  # Strategy: drop the entire query string. EXPLAIN ANALYZE doesn't need
+  # Prisma's pool/schema knobs, and `search_path` defaults to public anyway.
+  echo "${1%%\?*}"
+}
+
+if [[ -z "${DATABASE_URL:-}" ]]; then
+  ENV_SRC=""
+  if [[ -f ./.env ]]; then
+    ENV_SRC="./.env"
+  elif command -v git >/dev/null 2>&1; then
+    # In a git worktree without its own .env, look at the superproject.
+    super_root="$(git rev-parse --show-superproject-working-tree 2>/dev/null || true)"
+    if [[ -n "$super_root" && -f "$super_root/.env" ]]; then
+      ENV_SRC="$super_root/.env"
+    else
+      # Or, the main worktree of THIS repo (if we're in a non-superproject worktree).
+      common_dir="$(git rev-parse --git-common-dir 2>/dev/null || true)"
+      if [[ -n "$common_dir" ]]; then
+        main_worktree="$(dirname "$common_dir")"
+        if [[ -f "$main_worktree/.env" ]]; then
+          ENV_SRC="$main_worktree/.env"
+        fi
+      fi
+    fi
+  fi
+
+  if [[ -n "$ENV_SRC" ]]; then
+    DATABASE_URL="$(extract_database_url "$ENV_SRC")"
+    [[ -n "$DATABASE_URL" ]] && echo "→ Loaded DATABASE_URL from $ENV_SRC" >&2
   fi
 fi
 
 if [[ -z "${DATABASE_URL:-}" ]]; then
-  echo "✗ DATABASE_URL is not set (no ./.env either)." >&2
+  echo "✗ DATABASE_URL is not set, and no .env was found (cwd, superproject, or main worktree)." >&2
+  echo "  Set it explicitly: DATABASE_URL=postgres://... $0 '...'" >&2
   exit 1
 fi
 
-if ! command -v psql >/dev/null 2>&1; then
-  echo "✗ psql not found. Install: brew install libpq && brew link --force libpq" >&2
-  exit 1
+# Prisma URLs commonly include ?schema=public&connection_limit=... — psql
+# rejects those. Strip the query string for psql; the data path is unaffected.
+PSQL_URL="$(strip_prisma_params "$DATABASE_URL")"
+
+# --- psql resolution: prefer host psql, fall back to docker exec ---
+
+PSQL_CMD=()
+if command -v psql >/dev/null 2>&1; then
+  PSQL_CMD=(psql "$PSQL_URL" -X)
+else
+  CONTAINER="${PG_DOCKER_CONTAINER:-goodparty-postgres}"
+  if command -v docker >/dev/null 2>&1 && docker ps --format '{{.Names}}' 2>/dev/null | grep -qx "$CONTAINER"; then
+    echo "→ Using 'docker exec $CONTAINER psql' (host psql not on PATH)" >&2
+    PSQL_CMD=(docker exec -i "$CONTAINER" psql "$PSQL_URL" -X)
+  else
+    echo "✗ psql not on PATH and no '$CONTAINER' container running." >&2
+    case "$(uname -s)" in
+      Darwin) echo "  Install: brew install libpq && brew link --force libpq" >&2 ;;
+      Linux)
+        echo "  Install (Debian/Ubuntu): apt install postgresql-client" >&2
+        echo "  Install (Fedora/RHEL):   dnf install postgresql" >&2
+        ;;
+      *) echo "  Install psql for your platform." >&2 ;;
+    esac
+    echo "  Or set PG_DOCKER_CONTAINER=<name> if your container has a different name." >&2
+    echo "  (Looked for container: '$CONTAINER')" >&2
+    exit 1
+  fi
 fi
 
 if [[ -n "$FILE" ]]; then
@@ -63,4 +149,4 @@ EXPLAIN="EXPLAIN (ANALYZE, BUFFERS, VERBOSE, FORMAT $FORMAT) $QUERY;"
 
 echo "→ EXPLAIN (ANALYZE, BUFFERS, VERBOSE, FORMAT $FORMAT) <query>"
 echo
-exec psql "$DATABASE_URL" -X -c "$EXPLAIN"
+exec "${PSQL_CMD[@]}" -c "$EXPLAIN"

--- a/scripts/perf/explain.sh
+++ b/scripts/perf/explain.sh
@@ -48,6 +48,12 @@ while [[ $# -gt 0 ]]; do
     -h|--help)
       sed -n '2,/^set -/p' "$0" | sed 's/^# \{0,1\}//;/^set -/d'
       exit 0 ;;
+    -*)
+      # Reject unrecognized flags so typos (e.g. `--fromat JSON 'SELECT 1'`)
+      # don't get silently swallowed as QUERY values and produce a cryptic
+      # Postgres syntax error instead of a usage hint.
+      echo "✗ Unrecognized option: '$1'. Run with -h for usage." >&2
+      exit 2 ;;
     *) QUERY="$1"; shift ;;
   esac
 done
@@ -248,6 +254,19 @@ QUERY="${QUERY%;}"
 if [[ "$QUERY" == *";"* ]]; then
   echo "✗ Query contains interior ';' — EXPLAIN wraps exactly one statement." >&2
   echo "  Pass a single SELECT/INSERT/UPDATE/DELETE, with no internal semicolons." >&2
+  exit 2
+fi
+
+# SQL line comments (`--`) appended to the query would comment out the
+# trailing `; ROLLBACK;` in the assembled SQL string, defeating the
+# transaction safety wrapper. E.g. `'UPDATE foo SET x = 1 -- oops'` would
+# expand to `... UPDATE foo SET x = 1 -- oops; ROLLBACK;` and the
+# `ROLLBACK;` would never execute — the UPDATE would commit.
+# Block-comments (`/* ... */`) inside a single line don't have this hazard
+# because they're closed before the appended SQL; only line comments do.
+if [[ "$QUERY" == *"--"* ]]; then
+  echo "✗ Query contains '--' — this would comment out the ROLLBACK safety wrapper." >&2
+  echo "  Remove SQL line comments from the query before passing it to this script." >&2
   exit 2
 fi
 

--- a/scripts/perf/explain.sh
+++ b/scripts/perf/explain.sh
@@ -181,6 +181,20 @@ fi
 
 QUERY="${QUERY%;}"
 
+# EXPLAIN wraps exactly one statement. Interior ';' usually means the user
+# passed multiple statements (e.g. `-f migration.sql`) — psql splits on the
+# interior ';' and runs everything after the first statement *without* the
+# EXPLAIN wrapper, contradicting the user's intent. Reject early with a
+# clear message.
+# Note: this false-positives on queries with literal ';' inside string
+# literals (rare for EXPLAIN targets); rewrite the query to avoid them or
+# pass the relevant statement on its own.
+if [[ "$QUERY" == *";"* ]]; then
+  echo "✗ Query contains interior ';' — EXPLAIN wraps exactly one statement." >&2
+  echo "  Pass a single SELECT/INSERT/UPDATE/DELETE, with no internal semicolons." >&2
+  exit 2
+fi
+
 # Wrap in BEGIN; ... ROLLBACK; so DML/DDL queries passed by accident can't
 # mutate live data. EXPLAIN ANALYZE *executes* its argument unconditionally
 # (this is a no-op for SELECT, but `EXPLAIN ANALYZE UPDATE ... ` would

--- a/scripts/perf/explain.sh
+++ b/scripts/perf/explain.sh
@@ -19,8 +19,11 @@
 #   DATABASE_URL=postgres://... scripts/perf/explain.sh '...'
 #   PG_DOCKER_CONTAINER=my-pg scripts/perf/explain.sh 'SELECT 1'
 #
-# WARNING: EXPLAIN ANALYZE *executes* the query. Don't run UPDATE / DELETE
-# without wrapping in BEGIN; ROLLBACK; (psql -1 isn't enough on its own here).
+# NOTE: EXPLAIN ANALYZE *executes* its argument. This script always wraps
+# the EXPLAIN in `BEGIN; ... ROLLBACK;` so accidentally-passed DML/DDL
+# (UPDATE, DELETE, DROP, etc.) is rolled back — but transactional safety in
+# Postgres is not absolute (e.g. side-effects from functions like nextval()
+# persist). Still: don't deliberately pass write statements.
 set -euo pipefail
 
 FORMAT="TEXT"
@@ -76,11 +79,29 @@ extract_database_url() {
 
 strip_prisma_params() {
   # Strip Prisma-specific query parameters that vanilla psql doesn't understand
-  # (schema, connection_limit, pool_timeout, pgbouncer, etc.). Echoes the
-  # cleaned URL — safe to pass to psql.
-  # Strategy: drop the entire query string. EXPLAIN ANALYZE doesn't need
-  # Prisma's pool/schema knobs, and `search_path` defaults to public anyway.
+  # (connection_limit, pool_timeout, pgbouncer, schema, etc.). Echoes the
+  # cleaned URL — safe to pass to psql. The schema= value is preserved
+  # separately via extract_pg_schema() and set on the session below.
   echo "${1%%\?*}"
+}
+
+extract_pg_schema() {
+  # Extract the schema= value from a Prisma DATABASE_URL query string and
+  # validate it as a plain SQL identifier. Defaults to "public" if absent
+  # or non-conforming. $PG_SCHEMA is interpolated into the SQL string below,
+  # so it MUST be validated here — interpolating untrusted URL text is unsafe.
+  local qs schema
+  qs="${1#*\?}"
+  if [[ "$qs" == "$1" ]]; then
+    echo "public"
+    return
+  fi
+  schema="$(echo "$qs" | tr '&' '\n' | grep '^schema=' | head -1 | cut -d= -f2)"
+  if [[ "$schema" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]]; then
+    echo "$schema"
+  else
+    echo "public"
+  fi
 }
 
 if [[ -z "${DATABASE_URL:-}" ]]; then
@@ -117,8 +138,11 @@ if [[ -z "${DATABASE_URL:-}" ]]; then
 fi
 
 # Prisma URLs commonly include ?schema=public&connection_limit=... — psql
-# rejects those. Strip the query string for psql; the data path is unaffected.
+# rejects those. Strip the query string for psql, but keep the schema name
+# so we can set search_path explicitly (people-api uses ?schema=green for
+# the Voter table, so plain `"Voter"` lookups fail without this).
 PSQL_URL="$(strip_prisma_params "$DATABASE_URL")"
+PG_SCHEMA="$(extract_pg_schema "$DATABASE_URL")"
 
 # --- psql resolution: prefer host psql, fall back to docker exec ---
 
@@ -156,8 +180,16 @@ if [[ -z "$QUERY" ]]; then
 fi
 
 QUERY="${QUERY%;}"
-EXPLAIN="EXPLAIN (ANALYZE, BUFFERS, VERBOSE, FORMAT $FORMAT) $QUERY;"
+
+# Wrap in BEGIN; ... ROLLBACK; so DML/DDL queries passed by accident can't
+# mutate live data. EXPLAIN ANALYZE *executes* its argument unconditionally
+# (this is a no-op for SELECT, but `EXPLAIN ANALYZE UPDATE ... ` would
+# otherwise commit by default — and this script reads DATABASE_URL from the
+# environment, which can point at prod). SET LOCAL keeps search_path
+# changes scoped to this transaction.
+SQL="BEGIN; SET LOCAL search_path TO \"$PG_SCHEMA\", public; EXPLAIN (ANALYZE, BUFFERS, VERBOSE, FORMAT $FORMAT) $QUERY; ROLLBACK;"
 
 echo "→ EXPLAIN (ANALYZE, BUFFERS, VERBOSE, FORMAT $FORMAT) <query>"
+echo "  (wrapped in BEGIN; ROLLBACK; search_path=$PG_SCHEMA,public)"
 echo
-exec "${PSQL_CMD[@]}" -c "$EXPLAIN"
+exec "${PSQL_CMD[@]}" -c "$SQL"

--- a/scripts/perf/explain.sh
+++ b/scripts/perf/explain.sh
@@ -156,9 +156,28 @@ PG_SCHEMA="$(extract_pg_schema "$DATABASE_URL")"
 # ai-rules/security.md secrets must never appear there. We pass the
 # password via the PGPASSWORD env var instead (and forward it through
 # `docker exec -e PGPASSWORD` for the docker path).
+url_decode() {
+  # Decode %XX percent-encoding to literal bytes. libpq treats
+  # PGUSER/PGPASSWORD as literal strings (not URI-decoded), so any
+  # percent-encoded credential (e.g. `p%40ssword` for a literal `@` in
+  # the password — which MUST be encoded in the URL form) needs to be
+  # decoded here, or Postgres auth fails with a misleading "password
+  # authentication failed" message.
+  #   ${val//%/\\x} replaces every `%` with `\x` → e.g. `p%40ssword`
+  #   becomes `p\x40ssword`, then `printf '%b'` interprets the
+  #   backslash escapes — `\x40` → `@`.
+  local val="${1:-}"
+  [[ -z "$val" ]] && return
+  # Suppress printf's "missing hex digit for \x" for malformed `%` not
+  # followed by two hex digits — a malformed URL would fail auth anyway,
+  # and the warning would be misleading noise.
+  printf '%b' "${val//%/\\x}" 2>/dev/null
+}
+
 parse_pg_url() {
   # Accepts postgres://[user[:pass]@]host[:port]/db. Side-effects only:
-  # sets _pg_user, _pg_pass, _pg_host, _pg_port, _pg_db.
+  # sets _pg_user, _pg_pass, _pg_host, _pg_port, _pg_db. The user and
+  # password are URL-decoded so libpq sees the literal credential.
   local rest userinfo
   rest="${1#*://}"
   _pg_db="${rest##*/}"
@@ -169,10 +188,10 @@ parse_pg_url() {
     userinfo="${rest%@*}"
     rest="${rest##*@}"
     if [[ "$userinfo" == *:* ]]; then
-      _pg_user="${userinfo%%:*}"
-      _pg_pass="${userinfo#*:}"
+      _pg_user="$(url_decode "${userinfo%%:*}")"
+      _pg_pass="$(url_decode "${userinfo#*:}")"
     else
-      _pg_user="$userinfo"
+      _pg_user="$(url_decode "$userinfo")"
       _pg_pass=""
     fi
   else
@@ -257,16 +276,18 @@ if [[ "$QUERY" == *";"* ]]; then
   exit 2
 fi
 
-# SQL line comments (`--`) appended to the query would comment out the
-# trailing `; ROLLBACK;` in the assembled SQL string, defeating the
-# transaction safety wrapper. E.g. `'UPDATE foo SET x = 1 -- oops'` would
-# expand to `... UPDATE foo SET x = 1 -- oops; ROLLBACK;` and the
+# SQL line comments (`--`) on the LAST LINE of the query would comment
+# out the trailing `; ROLLBACK;` in the assembled SQL string, defeating
+# the transaction safety wrapper. E.g. `'UPDATE foo SET x = 1 -- oops'`
+# would expand to `... UPDATE foo SET x = 1 -- oops; ROLLBACK;` and the
 # `ROLLBACK;` would never execute — the UPDATE would commit.
-# Block-comments (`/* ... */`) inside a single line don't have this hazard
-# because they're closed before the appended SQL; only line comments do.
-if [[ "$QUERY" == *"--"* ]]; then
-  echo "✗ Query contains '--' — this would comment out the ROLLBACK safety wrapper." >&2
-  echo "  Remove SQL line comments from the query before passing it to this script." >&2
+# Comments on earlier lines are safe because the newline terminates the
+# line comment before the appended SQL. Block comments (`/* ... */`)
+# inside a single line are also safe — they're closed by `*/`.
+last_line="${QUERY##*$'\n'}"
+if [[ "$last_line" == *"--"* ]]; then
+  echo "✗ Query's last line contains '--' — this would comment out the ROLLBACK safety wrapper." >&2
+  echo "  Move or remove any SQL line comment at the end of the query." >&2
   exit 2
 fi
 

--- a/scripts/perf/explain.sh
+++ b/scripts/perf/explain.sh
@@ -144,16 +144,72 @@ fi
 PSQL_URL="$(strip_prisma_params "$DATABASE_URL")"
 PG_SCHEMA="$(extract_pg_schema "$DATABASE_URL")"
 
+# Parse the URL into components so we DON'T pass the whole connection
+# string (with embedded user:password) as a positional argument to psql /
+# docker exec. argv is visible to any local user via `ps aux`; per
+# ai-rules/security.md secrets must never appear there. We pass the
+# password via the PGPASSWORD env var instead (and forward it through
+# `docker exec -e PGPASSWORD` for the docker path).
+parse_pg_url() {
+  # Accepts postgres://[user[:pass]@]host[:port]/db. Side-effects only:
+  # sets _pg_user, _pg_pass, _pg_host, _pg_port, _pg_db.
+  local rest userinfo
+  rest="${1#*://}"
+  _pg_db="${rest##*/}"
+  rest="${rest%/*}"
+  if [[ "$rest" == *@* ]]; then
+    # %@* takes everything before the LAST @, so passwords containing
+    # un-encoded @ stay intact (rare but possible).
+    userinfo="${rest%@*}"
+    rest="${rest##*@}"
+    if [[ "$userinfo" == *:* ]]; then
+      _pg_user="${userinfo%%:*}"
+      _pg_pass="${userinfo#*:}"
+    else
+      _pg_user="$userinfo"
+      _pg_pass=""
+    fi
+  else
+    _pg_user=""
+    _pg_pass=""
+  fi
+  if [[ "$rest" == *:* ]]; then
+    _pg_host="${rest%%:*}"
+    _pg_port="${rest##*:}"
+  else
+    _pg_host="$rest"
+    _pg_port="5432"
+  fi
+}
+
+parse_pg_url "$PSQL_URL"
+
+# Export libpq connection parameters as env vars instead of passing them
+# in argv. This keeps the password out of `ps aux` and also handles the
+# edge case where any individual component is empty (a positional
+# `-U ""` would fail; an unset PGUSER falls back cleanly to libpq
+# defaults). Respect any pre-set caller values.
+[[ -n "$_pg_host" && -z "${PGHOST:-}"     ]] && export PGHOST="$_pg_host"
+[[ -n "$_pg_port" && -z "${PGPORT:-}"     ]] && export PGPORT="$_pg_port"
+[[ -n "$_pg_user" && -z "${PGUSER:-}"     ]] && export PGUSER="$_pg_user"
+[[ -n "$_pg_db"   && -z "${PGDATABASE:-}" ]] && export PGDATABASE="$_pg_db"
+[[ -n "$_pg_pass" && -z "${PGPASSWORD:-}" ]] && export PGPASSWORD="$_pg_pass"
+
 # --- psql resolution: prefer host psql, fall back to docker exec ---
 
 PSQL_CMD=()
 if command -v psql >/dev/null 2>&1; then
-  PSQL_CMD=(psql "$PSQL_URL" -X)
+  # Host psql inherits PGHOST/PGPORT/PGUSER/PGDATABASE/PGPASSWORD from env.
+  PSQL_CMD=(psql -X)
 else
   CONTAINER="${PG_DOCKER_CONTAINER:-goodparty-postgres}"
   if command -v docker >/dev/null 2>&1 && docker ps --format '{{.Names}}' 2>/dev/null | grep -qx "$CONTAINER"; then
     echo "→ Using 'docker exec $CONTAINER psql' (host psql not on PATH)" >&2
-    PSQL_CMD=(docker exec -i "$CONTAINER" psql "$PSQL_URL" -X)
+    # `-e VAR` (no value) forwards from the current env — keeps all
+    # connection parameters out of the docker exec argv.
+    PSQL_CMD=(docker exec -i \
+      -e PGHOST -e PGPORT -e PGUSER -e PGDATABASE -e PGPASSWORD \
+      "$CONTAINER" psql -X)
   else
     echo "✗ psql not on PATH and no '$CONTAINER' container running." >&2
     case "$(uname -s)" in

--- a/scripts/perf/explain.sh
+++ b/scripts/perf/explain.sh
@@ -263,6 +263,15 @@ else
 fi
 
 if [[ -n "$FILE" ]]; then
+  # Reject the both-provided case rather than silently dropping the
+  # positional query — EXPLAIN ANALYZE executes its argument, so the
+  # user would otherwise get a plan for a query they didn't intend to
+  # run with no indication that their positional input was ignored.
+  if [[ -n "$QUERY" ]]; then
+    echo "✗ Provide either a positional query string OR -f file.sql, not both." >&2
+    echo "  (Got both. The positional query would otherwise be silently dropped.)" >&2
+    exit 2
+  fi
   QUERY="$(cat "$FILE")"
 fi
 
@@ -294,11 +303,34 @@ fi
 # `ROLLBACK;` would never execute — the UPDATE would commit.
 # Comments on earlier lines are safe because the newline terminates the
 # line comment before the appended SQL. Block comments (`/* ... */`)
-# inside a single line are also safe — they're closed by `*/`.
+# inside a single line are safe *only when closed* — an unclosed `/*` on
+# the last line has the same effect as `--` (Postgres treats everything
+# after the unmatched `/*` as comment text, including our `; ROLLBACK;`).
 last_line="${QUERY##*$'\n'}"
 if [[ "$last_line" == *"--"* ]]; then
   echo "✗ Query's last line contains '--' — this would comment out the ROLLBACK safety wrapper." >&2
   echo "  Move or remove any SQL line comment at the end of the query." >&2
+  exit 2
+fi
+# Count `/*` vs `*/` on the last line; if open > close, there's an
+# unclosed block comment and the appended `; ROLLBACK;` becomes part
+# of it. Uses pure-bash substring stripping rather than `grep -o | wc -l`
+# because grep exits 1 when it finds no matches, and `set -o pipefail`
+# (line 27) would silently abort the script in the common "no comments
+# at all" case.
+_open_blk=0; _close_blk=0; _tmp="$last_line"
+while [[ "$_tmp" == *"/*"* ]]; do
+  _open_blk=$(( _open_blk + 1 ))
+  _tmp="${_tmp#*"/*"}"
+done
+_tmp="$last_line"
+while [[ "$_tmp" == *"*/"* ]]; do
+  _close_blk=$(( _close_blk + 1 ))
+  _tmp="${_tmp#*"*/"}"
+done
+if (( _open_blk > _close_blk )); then
+  echo "✗ Query's last line has an unclosed '/*' — this would comment out the ROLLBACK safety wrapper." >&2
+  echo "  Close the block comment with '*/' before the end of the query." >&2
   exit 2
 fi
 

--- a/scripts/perf/explain.sh
+++ b/scripts/perf/explain.sh
@@ -180,8 +180,19 @@ parse_pg_url() {
   # password are URL-decoded so libpq sees the literal credential.
   local rest userinfo
   rest="${1#*://}"
-  _pg_db="${rest##*/}"
-  rest="${rest%/*}"
+  # Split off the /dbname suffix ONLY if it's present. Without this guard,
+  # a URL like `postgres://u:p@host:5432` (no path) would leave _pg_db
+  # set to the entire `u:p@host:5432` string (leaking the password into
+  # PGDATABASE) and PGDATABASE would later cause psql to error with
+  # `database "u:p@host:5432" does not exist`. Empty _pg_db is fine —
+  # the export guards below skip empty values and libpq falls back to
+  # the user name.
+  if [[ "$rest" == */* ]]; then
+    _pg_db="${rest##*/}"
+    rest="${rest%/*}"
+  else
+    _pg_db=""
+  fi
   if [[ "$rest" == *@* ]]; then
     # %@* takes everything before the LAST @, so passwords containing
     # un-encoded @ stay intact (rare but possible).

--- a/scripts/perf/explain.sh
+++ b/scripts/perf/explain.sh
@@ -29,7 +29,18 @@ FILE=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --format) FORMAT="$2"; shift 2 ;;
+    --format)
+      # Whitelist against Postgres's four legal EXPLAIN FORMAT values.
+      # $FORMAT is interpolated into the SQL string later; without this
+      # check, '--format "TEXT) DROP TABLE foo; --"' would inject DDL.
+      case "${2:-}" in
+        TEXT|XML|JSON|YAML) FORMAT="$2" ;;
+        *)
+          echo "✗ Invalid --format value: '${2:-}'. Must be one of TEXT, XML, JSON, YAML." >&2
+          exit 2
+          ;;
+      esac
+      shift 2 ;;
     -f|--file) FILE="$2"; shift 2 ;;
     -h|--help)
       sed -n '2,/^set -/p' "$0" | sed 's/^# \{0,1\}//;/^set -/d'

--- a/scripts/perf/explain.sh
+++ b/scripts/perf/explain.sh
@@ -290,7 +290,14 @@ if [[ -z "$QUERY" ]]; then
   exit 2
 fi
 
-QUERY="${QUERY%;}"
+# Strip a trailing `;` along with any whitespace before it. Plain
+# `${QUERY%;}` only matches a bare semicolon, so `'SELECT 1 ;'` (common
+# when copy-pasting from psql or a SQL editor) would survive the strip
+# and then false-positive on the interior-semicolon check below. The
+# extglob `*([[:space:]]);` matches "zero-or-more whitespace then `;`".
+shopt -s extglob
+QUERY="${QUERY%%*([[:space:]]);}"
+shopt -u extglob
 
 # EXPLAIN wraps exactly one statement. Interior ';' usually means the user
 # passed multiple statements (e.g. `-f migration.sql`) — psql splits on the

--- a/scripts/perf/explain.sh
+++ b/scripts/perf/explain.sh
@@ -163,11 +163,21 @@ url_decode() {
   # the password — which MUST be encoded in the URL form) needs to be
   # decoded here, or Postgres auth fails with a misleading "password
   # authentication failed" message.
-  #   ${val//%/\\x} replaces every `%` with `\x` → e.g. `p%40ssword`
-  #   becomes `p\x40ssword`, then `printf '%b'` interprets the
-  #   backslash escapes — `\x40` → `@`.
+  #
+  # Steps:
+  # 1. Escape every pre-existing `\` to `\\`. Without this step,
+  #    `printf '%b'` would also interpret literal backslashes that
+  #    happened to be in the credential — e.g. a password containing
+  #    a literal `\n` would be silently turned into a newline, and
+  #    auth would fail with a misleading "password authentication
+  #    failed" error.
+  # 2. Replace every `%` with `\x` so `%XX` becomes `\xXX` — the only
+  #    backslash escape `printf '%b'` should interpret (since step 1
+  #    already doubled any pre-existing backslashes, they survive as
+  #    literal `\` after `%b`).
   local val="${1:-}"
   [[ -z "$val" ]] && return
+  val="${val//\\/\\\\}"
   # Suppress printf's "missing hex digit for \x" for malformed `%` not
   # followed by two hex digits — a malformed URL would fail auth anyway,
   # and the warning would be misleading noise.
@@ -312,27 +322,34 @@ if [[ "$last_line" == *"--"* ]]; then
   echo "  Move or remove any SQL line comment at the end of the query." >&2
   exit 2
 fi
-# Count `/*` vs `*/` on the last line; if open > close, there's an
-# unclosed block comment and the appended `; ROLLBACK;` becomes part
-# of it. Uses pure-bash substring stripping rather than `grep -o | wc -l`
-# because grep exits 1 when it finds no matches, and `set -o pipefail`
-# (line 27) would silently abort the script in the common "no comments
-# at all" case.
-_open_blk=0; _close_blk=0; _tmp="$last_line"
-while [[ "$_tmp" == *"/*"* ]]; do
-  _open_blk=$(( _open_blk + 1 ))
-  _tmp="${_tmp#*"/*"}"
-done
-_tmp="$last_line"
-while [[ "$_tmp" == *"*/"* ]]; do
-  _close_blk=$(( _close_blk + 1 ))
-  _tmp="${_tmp#*"*/"}"
-done
-if (( _open_blk > _close_blk )); then
-  echo "✗ Query's last line has an unclosed '/*' — this would comment out the ROLLBACK safety wrapper." >&2
-  echo "  Close the block comment with '*/' before the end of the query." >&2
-  exit 2
+# Reject any unclosed `/*` block comment ANYWHERE in the query (not just
+# the last line). The previous last-line-only check missed multi-line
+# cases like:
+#     SELECT 1 /*
+#     FROM foo
+# where `/*` opens on line 1 and the last line has no `/*` — but the
+# comment still extends to the end of the assembled SQL, swallowing
+# `; ROLLBACK;` and committing any DML. (Postgres usually parse-errors
+# this, which aborts the transaction and saves us — but defense in
+# depth: reject before the round-trip.)
+#
+# Algorithm: strip every matched `/* … */` pair, then if any `/*` is
+# left over it's unclosed. Uses perl with `-0` (whole input as one
+# record) so the regex spans newlines — sed without `-z` is line-by-
+# line on macOS and would false-positive on valid multi-line comments.
+# The regex `[^*]*(\*[^/][^*]*)*` is the standard "stuff inside a block
+# comment" subpattern.
+if command -v perl >/dev/null 2>&1; then
+  _stripped="$(printf '%s' "$QUERY" | perl -0pe 's|/\*[^*]*(\*[^/][^*]*)*\*/||g' 2>/dev/null || printf '%s' "$QUERY")"
+  if [[ "$_stripped" == *'/*'* ]]; then
+    echo "✗ Query contains an unclosed '/*' block comment — this would comment out the ROLLBACK safety wrapper." >&2
+    echo "  Close the block comment with '*/' before the end of the query." >&2
+    exit 2
+  fi
 fi
+# (If perl is unavailable we fall through — the last-line `--` guard
+# above still catches the original single-line `-- ` hazard, and
+# Postgres parse-errors an unclosed `/*`, which aborts the transaction.)
 
 # Wrap in BEGIN; ... ROLLBACK; so DML/DDL queries passed by accident can't
 # mutate live data. EXPLAIN ANALYZE *executes* its argument unconditionally

--- a/scripts/perf/profile-cpu.sh
+++ b/scripts/perf/profile-cpu.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# CPU profile a Node command via the V8 built-in sampler.
+# Backs up ai-rules/performance-tools.md §3.
+#
+# Usage:
+#   scripts/perf/profile-cpu.sh -- npm run start:prod
+#   scripts/perf/profile-cpu.sh -- node dist/main.js
+#   scripts/perf/profile-cpu.sh -- npx tsx scripts/some-job.ts
+#
+# Writes one or more .cpuprofile files to ./profiles/ (one per child process).
+# Stop a long-running server with ^C; one-shot scripts will exit on their own.
+#
+# After exit:
+#   - Open in Chrome DevTools: Performance tab → "Load profile…"
+#   - Or generate a flame graph: npx flamebearer < profiles/CPU.*.cpuprofile
+set -euo pipefail
+
+DIR="${PROFILE_DIR:-./profiles}"
+mkdir -p "$DIR"
+
+if [[ "${1:-}" == "--" ]]; then
+  shift
+fi
+
+if [[ $# -eq 0 ]]; then
+  echo "usage: $0 -- <command> [args...]" >&2
+  echo "  e.g. $0 -- npm run start:prod" >&2
+  echo "  e.g. $0 -- node dist/main.js" >&2
+  exit 2
+fi
+
+NODE_FLAGS="--cpu-prof --cpu-prof-dir=$DIR"
+
+echo "→ Profiling: $*"
+echo "  Profile dir: $DIR"
+echo "  (NODE_OPTIONS injected for child processes)"
+echo "  Stop a server with ^C; scripts exit on their own."
+echo
+
+export NODE_OPTIONS="${NODE_OPTIONS:-} $NODE_FLAGS"
+exec "$@"

--- a/scripts/perf/profile-cpu.sh
+++ b/scripts/perf/profile-cpu.sh
@@ -2,12 +2,24 @@
 # CPU profile a Node command via the V8 built-in sampler.
 # Backs up ai-rules/performance-tools.md §3.
 #
+# Requires: a direct `node` (or `tsx`/`npx tsx`) invocation of the workload —
+# NOT `npm run`, `nest start`, `next start`, or anything else that re-execs
+# node through a wrapper. Node 18+ rejects `--cpu-prof` in NODE_OPTIONS, which
+# is why this script does NOT inject it that way.
+#
 # Usage:
-#   scripts/perf/profile-cpu.sh -- npm run start:prod
 #   scripts/perf/profile-cpu.sh -- node dist/main.js
+#   scripts/perf/profile-cpu.sh -- tsx scripts/some-job.ts
 #   scripts/perf/profile-cpu.sh -- npx tsx scripts/some-job.ts
 #
-# Writes one or more .cpuprofile files to ./profiles/ (one per child process).
+# What about npm-script or nest-start targets?
+#   - Profile the underlying built JS file directly:
+#       scripts/perf/profile-cpu.sh -- node dist/main.js
+#   - OR add a temporary script in package.json and run that:
+#       "start:prod:profile": "node --cpu-prof --cpu-prof-dir=./profiles dist/main.js"
+#       npm run start:prod:profile
+#
+# Writes one or more .cpuprofile files to $PROFILE_DIR (default ./profiles).
 # Stop a long-running server with ^C; one-shot scripts will exit on their own.
 #
 # After exit:
@@ -16,7 +28,11 @@
 set -euo pipefail
 
 DIR="${PROFILE_DIR:-./profiles}"
-mkdir -p "$DIR"
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  sed -n '2,/^set -/p' "$0" | sed 's/^# \{0,1\}//;/^set -/d'
+  exit 0
+fi
 
 if [[ "${1:-}" == "--" ]]; then
   shift
@@ -24,18 +40,75 @@ fi
 
 if [[ $# -eq 0 ]]; then
   echo "usage: $0 -- <command> [args...]" >&2
-  echo "  e.g. $0 -- npm run start:prod" >&2
   echo "  e.g. $0 -- node dist/main.js" >&2
+  echo "       $0 -- tsx scripts/some-job.ts" >&2
+  echo "  run with --help for full notes." >&2
   exit 2
 fi
 
-NODE_FLAGS="--cpu-prof --cpu-prof-dir=$DIR"
+CMD="$1"
+shift
 
-echo "→ Profiling: $*"
-echo "  Profile dir: $DIR"
-echo "  (NODE_OPTIONS injected for child processes)"
-echo "  Stop a server with ^C; scripts exit on their own."
-echo
+case "$(basename "$CMD")" in
+  npm|pnpm|yarn|nest|next)
+    cat >&2 <<EOF
+✗ '$CMD' is an indirect entrypoint. Node 18+ rejects --cpu-prof when set via
+  NODE_OPTIONS, so this script cannot wrap '$CMD' transparently. Pick one:
 
-export NODE_OPTIONS="${NODE_OPTIONS:-} $NODE_FLAGS"
-exec "$@"
+    1. Profile the built JS directly:
+         $0 -- node dist/main.js
+
+    2. Add a one-off profiling script in package.json:
+         "start:prod:profile": "node --cpu-prof --cpu-prof-dir=$DIR dist/main.js"
+       then run:
+         npm run start:prod:profile
+
+  See ai-rules/performance-tools.md §3b for details.
+EOF
+    exit 2
+    ;;
+esac
+
+mkdir -p "$DIR"
+NODE_FLAGS=(--cpu-prof "--cpu-prof-dir=$DIR")
+
+case "$(basename "$CMD")" in
+  node)
+    echo "→ node ${NODE_FLAGS[*]} $*"
+    echo "  Stop with ^C; one-shot scripts exit on their own."
+    echo "  Profile dir: $DIR"
+    echo
+    exec node "${NODE_FLAGS[@]}" "$@"
+    ;;
+
+  tsx)
+    # Translate `tsx script.ts ...` → `node --cpu-prof ... --import tsx script.ts ...`
+    # (tsx must be installed in this project; node will error clearly if not.)
+    echo "→ node ${NODE_FLAGS[*]} --import tsx $*"
+    echo "  Profile dir: $DIR"
+    echo
+    exec node "${NODE_FLAGS[@]}" --import tsx "$@"
+    ;;
+
+  npx)
+    # Common pattern: `npx tsx script.ts ...` — translate same as above.
+    if [[ "${1:-}" == "tsx" ]]; then
+      shift
+      echo "→ node ${NODE_FLAGS[*]} --import tsx $*  (translated from 'npx tsx')"
+      echo "  Profile dir: $DIR"
+      echo
+      exec node "${NODE_FLAGS[@]}" --import tsx "$@"
+    fi
+    echo "✗ Unsupported: 'npx $*'. This script only auto-translates 'npx tsx <script>'." >&2
+    echo "  For other 'npx <tool>' targets, invoke node directly:" >&2
+    echo "    $0 -- node <path-to-the-tool's-bin> <args>" >&2
+    exit 2
+    ;;
+
+  *)
+    echo "✗ Unsupported entrypoint: '$CMD'." >&2
+    echo "  Supported: node | tsx | npx tsx" >&2
+    echo "  See '$0 --help' for how to profile npm-script / nest-start targets." >&2
+    exit 2
+    ;;
+esac

--- a/scripts/perf/profile-cpu.sh
+++ b/scripts/perf/profile-cpu.sh
@@ -85,9 +85,27 @@ require_local_tsx() {
   fi
 }
 
+# Echo the user's command shape without exposing the full argv. The
+# script path (first arg) is shown — it's never a secret — but everything
+# after is replaced with `<args>` to keep API keys, DB URLs, tokens,
+# etc. out of stdout / CI logs / shell history. The exec() below still
+# passes the unmodified "$@", so the program receives its real args.
+display_cmd_tail() {
+  # $1 = script path (or empty); rest = args. Echoes "script [N more args]".
+  local script="${1:-}"
+  shift || true
+  if [[ -z "$script" ]]; then
+    return
+  elif [[ $# -eq 0 ]]; then
+    echo -n "$script"
+  else
+    echo -n "$script <args>"
+  fi
+}
+
 case "$(basename "$CMD")" in
   node)
-    echo "→ node ${NODE_FLAGS[*]} $*"
+    echo "→ node ${NODE_FLAGS[*]} $(display_cmd_tail "$@")"
     echo "  Stop with ^C; one-shot scripts exit on their own."
     echo "  Profile dir: $DIR"
     echo
@@ -97,7 +115,7 @@ case "$(basename "$CMD")" in
   tsx)
     # Translate `tsx script.ts ...` → `node --cpu-prof ... --import tsx script.ts ...`
     require_local_tsx "tsx"
-    echo "→ node ${NODE_FLAGS[*]} --import tsx $*"
+    echo "→ node ${NODE_FLAGS[*]} --import tsx $(display_cmd_tail "$@")"
     echo "  Profile dir: $DIR"
     echo
     exec node "${NODE_FLAGS[@]}" --import tsx "$@"
@@ -108,12 +126,13 @@ case "$(basename "$CMD")" in
     if [[ "${1:-}" == "tsx" ]]; then
       shift
       require_local_tsx "npx tsx"
-      echo "→ node ${NODE_FLAGS[*]} --import tsx $*  (translated from 'npx tsx')"
+      echo "→ node ${NODE_FLAGS[*]} --import tsx $(display_cmd_tail "$@")  (translated from 'npx tsx')"
       echo "  Profile dir: $DIR"
       echo
       exec node "${NODE_FLAGS[@]}" --import tsx "$@"
     fi
-    echo "✗ Unsupported: 'npx $*'. This script only auto-translates 'npx tsx <script>'." >&2
+    # Only show the tool name (first arg), not its args.
+    echo "✗ Unsupported: 'npx ${1:-<empty>} …'. This script only auto-translates 'npx tsx <script>'." >&2
     echo "  For other 'npx <tool>' targets, invoke node directly:" >&2
     echo "    $0 -- node <path-to-the-tool's-bin> <args>" >&2
     exit 2

--- a/scripts/perf/profile-cpu.sh
+++ b/scripts/perf/profile-cpu.sh
@@ -72,6 +72,19 @@ esac
 mkdir -p "$DIR"
 NODE_FLAGS=(--cpu-prof "--cpu-prof-dir=$DIR")
 
+# `node --import tsx` requires tsx in node_modules; the global `tsx` binary
+# (or `npx tsx`) doesn't satisfy that. Fail fast with an actionable message
+# instead of letting node throw `ERR_MODULE_NOT_FOUND: Cannot find package 'tsx'`.
+require_local_tsx() {
+  if ! node -e "require.resolve('tsx')" >/dev/null 2>&1; then
+    echo "✗ This script translates '$1' to 'node --import tsx', which needs tsx in node_modules." >&2
+    echo "  tsx is NOT installed locally in this project." >&2
+    echo "  Either install it:    npm install --save-dev tsx" >&2
+    echo "  Or profile node directly: $0 -- node dist/<your-built-script>.js" >&2
+    exit 2
+  fi
+}
+
 case "$(basename "$CMD")" in
   node)
     echo "→ node ${NODE_FLAGS[*]} $*"
@@ -83,7 +96,7 @@ case "$(basename "$CMD")" in
 
   tsx)
     # Translate `tsx script.ts ...` → `node --cpu-prof ... --import tsx script.ts ...`
-    # (tsx must be installed in this project; node will error clearly if not.)
+    require_local_tsx "tsx"
     echo "→ node ${NODE_FLAGS[*]} --import tsx $*"
     echo "  Profile dir: $DIR"
     echo
@@ -94,6 +107,7 @@ case "$(basename "$CMD")" in
     # Common pattern: `npx tsx script.ts ...` — translate same as above.
     if [[ "${1:-}" == "tsx" ]]; then
       shift
+      require_local_tsx "npx tsx"
       echo "→ node ${NODE_FLAGS[*]} --import tsx $*  (translated from 'npx tsx')"
       echo "  Profile dir: $DIR"
       echo

--- a/scripts/perf/profile-cpu.sh
+++ b/scripts/perf/profile-cpu.sh
@@ -103,8 +103,20 @@ display_cmd_tail() {
   fi
 }
 
+# Without these guards, `profile-cpu.sh -- node` (or `-- tsx`, `-- npx tsx`)
+# with no following script argument would `exec node …` with no script,
+# silently launching an interactive REPL — no .cpuprofile written, no
+# error printed, the process just hangs at a Node prompt. The outer
+# `$# -eq 0` check on a fully-empty invocation fires before $CMD is
+# consumed, so it doesn't cover these cases.
 case "$(basename "$CMD")" in
   node)
+    if [[ $# -eq 0 ]]; then
+      echo "✗ Missing script argument for 'node'." >&2
+      echo "  Usage: $0 -- node <script-or-dist-entry> [args...]" >&2
+      echo "  Example: $0 -- node dist/main.js" >&2
+      exit 2
+    fi
     echo "→ node ${NODE_FLAGS[*]} $(display_cmd_tail "$@")"
     echo "  Stop with ^C; one-shot scripts exit on their own."
     echo "  Profile dir: $DIR"
@@ -114,6 +126,11 @@ case "$(basename "$CMD")" in
 
   tsx)
     # Translate `tsx script.ts ...` → `node --cpu-prof ... --import tsx script.ts ...`
+    if [[ $# -eq 0 ]]; then
+      echo "✗ Missing script argument for 'tsx'." >&2
+      echo "  Usage: $0 -- tsx <script.ts> [args...]" >&2
+      exit 2
+    fi
     require_local_tsx "tsx"
     echo "→ node ${NODE_FLAGS[*]} --import tsx $(display_cmd_tail "$@")"
     echo "  Profile dir: $DIR"
@@ -125,6 +142,11 @@ case "$(basename "$CMD")" in
     # Common pattern: `npx tsx script.ts ...` — translate same as above.
     if [[ "${1:-}" == "tsx" ]]; then
       shift
+      if [[ $# -eq 0 ]]; then
+        echo "✗ Missing script argument for 'npx tsx'." >&2
+        echo "  Usage: $0 -- npx tsx <script.ts> [args...]" >&2
+        exit 2
+      fi
       require_local_tsx "npx tsx"
       echo "→ node ${NODE_FLAGS[*]} --import tsx $(display_cmd_tail "$@")  (translated from 'npx tsx')"
       echo "  Profile dir: $DIR"

--- a/scripts/perf/setup-check.sh
+++ b/scripts/perf/setup-check.sh
@@ -147,8 +147,9 @@ fi
 if [[ -f ai-rules/performance.md ]]; then
   printf "  %s  ai-rules/performance.md present (submodule initialized)\n" "$OK"
 elif [[ -f ai-rules/README.md ]]; then
-  printf "  %s  ai-rules submodule initialized but performance.md missing — pointer may be stale\n" "$WARN"
-  echo "       Update: (cd ai-rules && git fetch && git checkout origin/main)"
+  printf "  %s  ai-rules submodule initialized but performance.md missing — submodule out of sync with the recorded pointer\n" "$WARN"
+  echo "       Sync: git submodule update ai-rules"
+  echo "       (Don't 'git checkout origin/main' inside the submodule — that lands at a tree that may not contain performance.md.)"
 elif [[ -e ai-rules ]] || git config -f .gitmodules --get submodule.ai-rules.url >/dev/null 2>&1; then
   printf "  %s  ai-rules submodule NOT initialized\n" "$NO"
   echo "       Run: git submodule update --init --recursive"

--- a/scripts/perf/setup-check.sh
+++ b/scripts/perf/setup-check.sh
@@ -95,7 +95,21 @@ if [[ -z "$DBURL" ]]; then
     fi
   fi
   if [[ -n "$ENV_SRC" ]]; then
-    DBURL="$(grep -E '^DATABASE_URL[[:space:]]*=' "$ENV_SRC" | head -1 | sed 's/^[^=]*=//; s/^[\"\x27]//; s/[\"\x27]$//')"
+    # Match explain.sh's extract_database_url() so we don't silently report
+    # GREEN for a value that explain.sh would reject. Handles single/double
+    # quotes and trailing inline comments.
+    _raw="$(grep -E '^DATABASE_URL[[:space:]]*=' "$ENV_SRC" | head -1 || true)"
+    if [[ -n "$_raw" ]]; then
+      _val="${_raw#*=}"
+      if [[ "$_val" == \"* ]]; then
+        _val="${_val#\"}"; _val="${_val%%\"*}"
+      elif [[ "$_val" == \'* ]]; then
+        _val="${_val#\'}"; _val="${_val%%\'*}"
+      else
+        _val="${_val%%#*}"; _val="${_val%%[[:space:]]*}"
+      fi
+      DBURL="$_val"
+    fi
   fi
 fi
 if [[ -n "$DBURL" ]]; then

--- a/scripts/perf/setup-check.sh
+++ b/scripts/perf/setup-check.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# Check that the local environment can run scripts/perf/*.sh end-to-end.
+# Backs up ai-rules/performance-tools.md §11.6 (Agents in fresh worktrees).
+#
+# Reports — does NOT install anything, does NOT start any service.
+# Exits 0 always; the report is informational. Treat any ✗ as something to
+# fix before claiming a measurement from the affected tool.
+#
+# Usage:
+#   scripts/perf/setup-check.sh
+#   PORT=3000 scripts/perf/setup-check.sh
+#
+# Env overrides:
+#   PORT                  (default 3002 — people-api .env.example default)
+#   HOST                  (default localhost)
+#   PG_DOCKER_CONTAINER   (default goodparty-postgres)
+set -euo pipefail
+
+PORT="${PORT:-3002}"
+HOST="${HOST:-localhost}"
+CONTAINER="${PG_DOCKER_CONTAINER:-goodparty-postgres}"
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  sed -n '2,/^set -/p' "$0" | sed 's/^# \{0,1\}//;/^set -/d'
+  exit 0
+fi
+
+OK="✓"
+NO="✗"
+WARN="⚠"
+
+check() {
+  local label="$1" cmd="$2" hint="${3:-}"
+  if eval "$cmd" >/dev/null 2>&1; then
+    printf "  %s  %s\n" "$OK" "$label"
+  else
+    printf "  %s  %s\n" "$NO" "$label"
+    [[ -n "$hint" ]] && printf "       %s\n" "$hint"
+  fi
+  return 0
+}
+
+note() {
+  printf "  %s  %s\n" "$WARN" "$1"
+}
+
+echo
+echo "scripts/perf/ environment check (people-api)"
+echo "============================================"
+echo
+
+echo "Tools:"
+check "node $(node --version 2>/dev/null || echo '(not found)')" \
+      'command -v node' \
+      'Install Node 22.x via nvm / fnm / mise.'
+check "autocannon (HTTP load — §1)" \
+      'command -v autocannon' \
+      'Falls back to: npx --yes autocannon (no install needed; first run is slow).'
+check "hyperfine (statistical bench — §0)" \
+      'command -v hyperfine' \
+      "Install: brew install hyperfine  (mac) | cargo install hyperfine (linux)."
+check "k6 (multi-endpoint scenarios — §2)" \
+      'command -v k6' \
+      "Install: brew install k6  (mac) | apt install k6 (linux, Grafana repo) | docker run --rm grafana/k6"
+
+echo
+echo "Database:"
+if command -v psql >/dev/null 2>&1; then
+  check "psql on PATH" 'command -v psql'
+elif command -v docker >/dev/null 2>&1 && docker ps --format '{{.Names}}' 2>/dev/null | grep -qx "$CONTAINER"; then
+  printf "  %s  docker exec %s psql (host psql not on PATH — docker fallback available)\n" "$OK" "$CONTAINER"
+else
+  printf "  %s  no psql AND no '%s' container running\n" "$NO" "$CONTAINER"
+  case "$(uname -s)" in
+    Darwin) echo "       Install: brew install libpq && brew link --force libpq" ;;
+    Linux)  echo "       Install: apt install postgresql-client  (debian/ubuntu)" ;;
+  esac
+  echo "       Or set PG_DOCKER_CONTAINER=<name> if your container has a different name."
+fi
+
+DBURL="${DATABASE_URL:-}"
+ENV_SRC=""
+if [[ -z "$DBURL" ]]; then
+  if [[ -f ./.env ]]; then
+    ENV_SRC="./.env"
+  elif command -v git >/dev/null 2>&1; then
+    super="$(git rev-parse --show-superproject-working-tree 2>/dev/null || true)"
+    if [[ -n "$super" && -f "$super/.env" ]]; then
+      ENV_SRC="$super/.env"
+    else
+      cdir="$(git rev-parse --git-common-dir 2>/dev/null || true)"
+      if [[ -n "$cdir" && -f "$(dirname "$cdir")/.env" ]]; then
+        ENV_SRC="$(dirname "$cdir")/.env"
+      fi
+    fi
+  fi
+  if [[ -n "$ENV_SRC" ]]; then
+    DBURL="$(grep -E '^DATABASE_URL[[:space:]]*=' "$ENV_SRC" | head -1 | sed 's/^[^=]*=//; s/^[\"\x27]//; s/[\"\x27]$//')"
+  fi
+fi
+if [[ -n "$DBURL" ]]; then
+  if [[ -n "$ENV_SRC" ]]; then
+    printf "  %s  DATABASE_URL resolvable (from %s)\n" "$OK" "$ENV_SRC"
+  else
+    printf "  %s  DATABASE_URL resolvable (from env)\n" "$OK"
+  fi
+else
+  printf "  %s  DATABASE_URL not found in env, ./.env, or parent worktree .env\n" "$NO"
+  echo "       Set: export DATABASE_URL=postgres://..."
+fi
+
+echo
+echo "App:"
+if command -v curl >/dev/null 2>&1; then
+  if curl -fsS -o /dev/null --max-time 2 "http://${HOST}:${PORT}/" 2>/dev/null \
+     || curl -fsS -o /dev/null --max-time 2 "http://${HOST}:${PORT}/health" 2>/dev/null; then
+    printf "  %s  people-api reachable at http://%s:%s\n" "$OK" "$HOST" "$PORT"
+  else
+    printf "  %s  no listener on http://%s:%s (start: npm run start:dev)\n" "$WARN" "$HOST" "$PORT"
+  fi
+else
+  note "curl not available — skipping server reachability check"
+fi
+
+echo
+echo "Repo state:"
+if [[ -d node_modules ]]; then
+  printf "  %s  node_modules present\n" "$OK"
+else
+  printf "  %s  node_modules missing (run: npm ci)\n" "$NO"
+fi
+
+if [[ -f ai-rules/performance.md ]]; then
+  printf "  %s  ai-rules/performance.md present (submodule initialized)\n" "$OK"
+elif [[ -f ai-rules/README.md ]]; then
+  printf "  %s  ai-rules submodule initialized but performance.md missing — pointer may be stale\n" "$WARN"
+  echo "       Update: (cd ai-rules && git fetch && git checkout origin/main)"
+elif [[ -e ai-rules ]] || git config -f .gitmodules --get submodule.ai-rules.url >/dev/null 2>&1; then
+  printf "  %s  ai-rules submodule NOT initialized\n" "$NO"
+  echo "       Run: git submodule update --init --recursive"
+else
+  note "ai-rules submodule not present in this repo"
+fi
+
+echo
+echo "Done. Anything marked ✗ above is a real blocker for the relevant tool."
+echo "Anything marked ⚠ is informational — usually fine for some tools, not for others."
+exit 0

--- a/scripts/perf/setup-check.sh
+++ b/scripts/perf/setup-check.sh
@@ -8,15 +8,15 @@
 #
 # Usage:
 #   scripts/perf/setup-check.sh
-#   PORT=3000 scripts/perf/setup-check.sh
+#   PORT=3001 scripts/perf/setup-check.sh
 #
 # Env overrides:
-#   PORT                  (default 3002 — people-api .env.example default)
+#   PORT                  (default 3000 — the gp-api dev server port)
 #   HOST                  (default localhost)
 #   PG_DOCKER_CONTAINER   (default goodparty-postgres)
 set -euo pipefail
 
-PORT="${PORT:-3002}"
+PORT="${PORT:-3000}"
 HOST="${HOST:-localhost}"
 CONTAINER="${PG_DOCKER_CONTAINER:-goodparty-postgres}"
 
@@ -30,6 +30,8 @@ NO="✗"
 WARN="⚠"
 
 check() {
+  # $1 = label, $2 = command (eval-safe), $3 = optional remediation hint
+  # Always returns 0 — the printed glyph is the result. Keeps `set -e` happy.
   local label="$1" cmd="$2" hint="${3:-}"
   if eval "$cmd" >/dev/null 2>&1; then
     printf "  %s  %s\n" "$OK" "$label"
@@ -45,8 +47,8 @@ note() {
 }
 
 echo
-echo "scripts/perf/ environment check (people-api)"
-echo "============================================"
+echo "scripts/perf/ environment check"
+echo "================================"
 echo
 
 echo "Tools:"
@@ -59,9 +61,6 @@ check "autocannon (HTTP load — §1)" \
 check "hyperfine (statistical bench — §0)" \
       'command -v hyperfine' \
       "Install: brew install hyperfine  (mac) | cargo install hyperfine (linux)."
-check "k6 (multi-endpoint scenarios — §2)" \
-      'command -v k6' \
-      "Install: brew install k6  (mac) | apt install k6 (linux, Grafana repo) | docker run --rm grafana/k6"
 
 echo
 echo "Database:"
@@ -75,9 +74,10 @@ else
     Darwin) echo "       Install: brew install libpq && brew link --force libpq" ;;
     Linux)  echo "       Install: apt install postgresql-client  (debian/ubuntu)" ;;
   esac
-  echo "       Or set PG_DOCKER_CONTAINER=<name> if your container has a different name."
+  echo "       Or: docker compose up -d  (per the repo's docker-compose.yml)"
 fi
 
+# DATABASE_URL resolution — same logic as explain.sh, but read-only.
 DBURL="${DATABASE_URL:-}"
 ENV_SRC=""
 if [[ -z "$DBURL" ]]; then
@@ -126,9 +126,8 @@ fi
 echo
 echo "App:"
 if command -v curl >/dev/null 2>&1; then
-  if curl -fsS -o /dev/null --max-time 2 "http://${HOST}:${PORT}/" 2>/dev/null \
-     || curl -fsS -o /dev/null --max-time 2 "http://${HOST}:${PORT}/health" 2>/dev/null; then
-    printf "  %s  people-api reachable at http://%s:%s\n" "$OK" "$HOST" "$PORT"
+  if curl -fsS -o /dev/null --max-time 2 "http://${HOST}:${PORT}/health" 2>/dev/null; then
+    printf "  %s  gp-api dev server reachable at http://%s:%s/health\n" "$OK" "$HOST" "$PORT"
   else
     printf "  %s  no listener on http://%s:%s (start: npm run start:dev)\n" "$WARN" "$HOST" "$PORT"
   fi
@@ -136,6 +135,7 @@ else
   note "curl not available — skipping server reachability check"
 fi
 
+# Repo-local node_modules + ai-rules submodule (helpful in fresh worktrees).
 echo
 echo "Repo state:"
 if [[ -d node_modules ]]; then
@@ -144,12 +144,24 @@ else
   printf "  %s  node_modules missing (run: npm ci)\n" "$NO"
 fi
 
-if [[ -f ai-rules/performance.md ]]; then
-  printf "  %s  ai-rules/performance.md present (submodule initialized)\n" "$OK"
+# Check the file these wrapper scripts actually reference: performance-tools.md
+# (the tools cookbook). performance.md is the critic rule; both should be
+# present on a healthy submodule pointer, but performance-tools.md is what
+# the scripts in this directory header-cite — so checking it gives a more
+# faithful "is the submodule aligned with what this toolchain depends on"
+# answer.
+if [[ -f ai-rules/performance-tools.md ]]; then
+  printf "  %s  ai-rules/performance-tools.md present (submodule initialized)\n" "$OK"
+  # Sanity-check the critic rule file too — different file, same submodule;
+  # if one is present and the other isn't, the pointer is partially stale.
+  if [[ ! -f ai-rules/performance.md ]]; then
+    printf "  %s  ai-rules/performance.md missing — submodule pointer may be partially stale\n" "$WARN"
+    echo "       Sync: git submodule update ai-rules"
+  fi
 elif [[ -f ai-rules/README.md ]]; then
-  printf "  %s  ai-rules submodule initialized but performance.md missing — submodule out of sync with the recorded pointer\n" "$WARN"
+  printf "  %s  ai-rules submodule initialized but performance-tools.md missing — submodule out of sync with the recorded pointer\n" "$WARN"
   echo "       Sync: git submodule update ai-rules"
-  echo "       (Don't 'git checkout origin/main' inside the submodule — that lands at a tree that may not contain performance.md.)"
+  echo "       (Don't 'git checkout origin/main' inside the submodule — that lands at a tree that may not contain performance-tools.md.)"
 elif [[ -e ai-rules ]] || git config -f .gitmodules --get submodule.ai-rules.url >/dev/null 2>&1; then
   printf "  %s  ai-rules submodule NOT initialized\n" "$NO"
   echo "       Run: git submodule update --init --recursive"

--- a/scripts/perf/setup-check.sh
+++ b/scripts/perf/setup-check.sh
@@ -8,15 +8,15 @@
 #
 # Usage:
 #   scripts/perf/setup-check.sh
-#   PORT=3001 scripts/perf/setup-check.sh
+#   PORT=3002 scripts/perf/setup-check.sh
 #
 # Env overrides:
-#   PORT                  (default 3000 — the gp-api dev server port)
+#   PORT                  (default 3002 — the people-api dev server port; .env.example uses 3002)
 #   HOST                  (default localhost)
 #   PG_DOCKER_CONTAINER   (default goodparty-postgres)
 set -euo pipefail
 
-PORT="${PORT:-3000}"
+PORT="${PORT:-3002}"
 HOST="${HOST:-localhost}"
 CONTAINER="${PG_DOCKER_CONTAINER:-goodparty-postgres}"
 
@@ -127,7 +127,7 @@ echo
 echo "App:"
 if command -v curl >/dev/null 2>&1; then
   if curl -fsS -o /dev/null --max-time 2 "http://${HOST}:${PORT}/health" 2>/dev/null; then
-    printf "  %s  gp-api dev server reachable at http://%s:%s/health\n" "$OK" "$HOST" "$PORT"
+    printf "  %s  people-api dev server reachable at http://%s:%s/health\n" "$OK" "$HOST" "$PORT"
   else
     printf "  %s  no listener on http://%s:%s (start: npm run start:dev)\n" "$WARN" "$HOST" "$PORT"
   fi


### PR DESCRIPTION
## Summary

Adds convenience wrappers behind the canonical commands in [`ai-rules/performance-tools.md`](https://github.com/thegoodparty/ai-rules/blob/main/performance-tools.md) (see companion PR [thegoodparty/ai-rules#9](https://github.com/thegoodparty/ai-rules/pull/9)).

These **complement** the existing k6-based `perf/` directory (and `npm run perf:*` scripts) — they're for quick single-purpose measurements, while `perf/` + k6 remains the home for multi-endpoint scenario tests.

| Script | What it does | Cookbook section |
|---|---|---|
| `scripts/perf/bench-endpoint.sh` | Single-endpoint HTTP load test (autocannon) | §1 |
| `scripts/perf/profile-cpu.sh` | V8 CPU profile of any node command (`.cpuprofile`) | §3 |
| `scripts/perf/explain.sh` | `EXPLAIN (ANALYZE, BUFFERS, VERBOSE)` wrapping `psql` | §5 |
| `scripts/perf/README.md` | Prereqs, examples, critic tie-in | — |

All scripts are self-documenting (`-h`/`--help`), detect missing tools with install hints, and accept env-var overrides (`PORT`, `HOST`, `PROTO`, `DATABASE_URL`).

## Critic tie-in

Per the [performance critic rules](https://github.com/thegoodparty/ai-rules/blob/main/performance.md), any PR that claims a performance improvement should include before/after numbers from one of these tools (or production telemetry). Without a measurement, the change is a refactor. The README documents this expectation.

## Test plan

- [ ] `scripts/perf/bench-endpoint.sh --help` renders usage
- [ ] `scripts/perf/profile-cpu.sh` renders usage when called with no args
- [ ] `scripts/perf/explain.sh --help` renders usage
- [ ] With local server running: `scripts/perf/bench-endpoint.sh /health` produces an autocannon latency table
- [ ] With `DATABASE_URL` set: `scripts/perf/explain.sh 'SELECT 1'` returns an EXPLAIN plan
- [ ] Verify the new scripts don't conflict with `npm run perf:core` / `perf:mixed`

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and dev-only shell scripts; no runtime, auth, or production code paths change.
> 
> **Overview**
> Introduces **`scripts/perf/`** as thin bash wrappers aligned with **`ai-rules/performance-tools.md`**, so engineers can run quick measurements without digging through the cookbook. They sit **alongside** the existing **`perf/`** k6 scenarios and **`npm run perf:*`** flows—not replacements.
> 
> **`bench-endpoint.sh`** runs **autocannon** against a path or full URL, with defaults (10 connections, 20s), **`PORT`/`HOST`/`PROTO`** overrides, passthrough flags, and a missing-tool install hint.
> 
> **`profile-cpu.sh`** wraps any Node command with **`NODE_OPTIONS`** for V8 **`.cpuprofile`** output under **`./profiles`** (or **`PROFILE_DIR`**).
> 
> **`explain.sh`** runs **`EXPLAIN (ANALYZE, BUFFERS, VERBOSE)`** via **`psql`**, loading **`DATABASE_URL`** from the env or a safe **`.env`** line parse, with **`-f`** / **`--format`** and a warning that analyze executes the query.
> 
> **`README.md`** documents prereqs, examples (including **hyperfine** commit comparisons and tying plans into **`perf/query-plans.md`**), and the performance-critic expectation that claimed wins include before/after numbers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b145c4f4099c60b950826e9d1fced69411fc99f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->