### PR TITLE
chore(prisma): isolate client into per-package output dir (monorepo prep)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,5 +22,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Generate Prisma client
+        run: npm run generate
+
       - name: Run tests
         run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 dist/
 api/dist
 
+# generated prisma client (per-package output dir)
+src/generated/
+
 # Node.js runtime environment
 node_modules
 nestjs/node_modules

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -73,6 +73,11 @@ RUN npm ci --only=production --ignore-scripts
 # Copy only necessary files to the runtime image
 COPY --from=builder /app/node_modules/.prisma ./node_modules/.prisma
 COPY --from=builder /app/dist ./dist
+# Prisma client now generates to a per-package output dir (src/generated/prisma)
+# instead of node_modules/.prisma. tsc does not emit these prebuilt JS files or
+# the query-engine binary, so copy them to where the compiled dist code resolves
+# them: dist/src/people/.../*.js require('../../generated/prisma') -> dist/src/generated/prisma.
+COPY --from=builder /app/src/generated/prisma ./dist/src/generated/prisma
 COPY --from=builder /app/prisma ./prisma
 COPY module-alias.js ./
 

--- a/prisma/schema/schema.prisma
+++ b/prisma/schema/schema.prisma
@@ -7,6 +7,7 @@ datasource db {
 generator client {
   provider        = "prisma-client-js"
   previewFeatures = ["multiSchema", "prismaSchemaFolder"]
+  output          = "../../src/generated/prisma"
 }
 
 generator json {

--- a/seed/factories/voter.factory.ts
+++ b/seed/factories/voter.factory.ts
@@ -1,5 +1,5 @@
 import { faker } from '@faker-js/faker'
-import { Voter, USState } from '@prisma/client'
+import { Voter, USState } from '../../src/generated/prisma'
 import { generateFactory } from './generate'
 
 // we need to match the seed to the gp-api office seed.

--- a/seed/seed.ts
+++ b/seed/seed.ts
@@ -1,4 +1,4 @@
-// import { PrismaClient } from '@prisma/client'
+// import { PrismaClient } from '../src/generated/prisma'
 // // import seedVoters from './voters'
 
 // // const LIMIT_SEEDS =

--- a/seed/voters.ts
+++ b/seed/voters.ts
@@ -1,4 +1,4 @@
-// import { Prisma, PrismaClient } from '@prisma/client'
+// import { Prisma, PrismaClient } from '../src/generated/prisma'
 // import { voterFactory } from './factories/voter.factory'
 // import { randomUUID } from 'crypto'
 

--- a/src/people/people.select.ts
+++ b/src/people/people.select.ts
@@ -1,4 +1,4 @@
-import { Prisma, Voter } from '@prisma/client'
+import { Prisma, Voter } from '../generated/prisma'
 
 const VOTER_SELECT_COLUMNS = [
   'id',

--- a/src/people/services/people.service.ts
+++ b/src/people/services/people.service.ts
@@ -1,4 +1,4 @@
-import { Prisma } from '@prisma/client'
+import { Prisma } from '../../generated/prisma'
 import {
   GetPersonQueryDTO,
   ListPeopleDTO,

--- a/src/people/services/sample.service.ts
+++ b/src/people/services/sample.service.ts
@@ -1,5 +1,5 @@
 import { BadRequestException, Injectable } from '@nestjs/common'
-import { Prisma } from '@prisma/client'
+import { Prisma } from '../../generated/prisma'
 import { createPrismaBase, MODELS } from 'src/prisma/util/prisma.util'
 import { samplePeopleSchema } from '../people.schema'
 import { BaseDbPerson, buildVoterSelectSql } from '../people.select'

--- a/src/people/services/stats.service.ts
+++ b/src/people/services/stats.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, NotFoundException } from '@nestjs/common'
-import { DistrictStats } from '@prisma/client'
+import { DistrictStats } from '../../generated/prisma'
 import { createPrismaBase, MODELS } from 'src/prisma/util/prisma.util'
 import { StatsDTO } from '../people.schema'
 

--- a/src/people/utils/buildVoterWhereSql.utils.ts
+++ b/src/people/utils/buildVoterWhereSql.utils.ts
@@ -1,4 +1,4 @@
-import { Prisma } from '@prisma/client'
+import { Prisma } from '../../generated/prisma'
 import { FilterData } from '../schemas/filters.schema'
 import { buildVoterFiltersSql } from './filters.sql.utils'
 

--- a/src/people/utils/filters.sql.utils.test.ts
+++ b/src/people/utils/filters.sql.utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { Prisma } from '@prisma/client'
+import { Prisma } from '../../generated/prisma'
 import { buildVoterFiltersSql } from './filters.sql.utils'
 import { FilterData } from '../schemas/filters.schema'
 

--- a/src/people/utils/filters.sql.utils.ts
+++ b/src/people/utils/filters.sql.utils.ts
@@ -1,4 +1,4 @@
-import { Prisma } from '@prisma/client'
+import { Prisma } from '../../generated/prisma'
 import { FilterData } from '../schemas/filters.schema'
 import { FilterOperator } from '../schemas/filters.schema.utils'
 

--- a/src/people/utils/inlinePrismaSql.utils.test.ts
+++ b/src/people/utils/inlinePrismaSql.utils.test.ts
@@ -1,4 +1,4 @@
-import { Prisma } from '@prisma/client'
+import { Prisma } from '../../generated/prisma'
 import { describe, expect, it } from 'vitest'
 import { inlinePrismaSql } from './inlinePrismaSql.utils'
 

--- a/src/people/utils/inlinePrismaSql.utils.ts
+++ b/src/people/utils/inlinePrismaSql.utils.ts
@@ -1,4 +1,4 @@
-import type { Prisma } from '@prisma/client'
+import type { Prisma } from '../../generated/prisma'
 import type { PoolClient } from 'pg'
 
 /**

--- a/src/prisma/prisma.service.ts
+++ b/src/prisma/prisma.service.ts
@@ -4,7 +4,7 @@ import {
   OnModuleDestroy,
   OnModuleInit,
 } from '@nestjs/common'
-import { Prisma, PrismaClient } from '@prisma/client'
+import { Prisma, PrismaClient } from '../generated/prisma'
 
 const PRISMA_LOG_LEVELS = [
   'info',

--- a/src/prisma/util/prisma.util.ts
+++ b/src/prisma/util/prisma.util.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable, Logger, OnModuleInit } from '@nestjs/common'
 import { PrismaService } from '../prisma.service'
-import { Prisma, PrismaClient } from '@prisma/client'
+import { Prisma, PrismaClient } from '../../generated/prisma'
 import { lowerFirst } from 'lodash'
 
 export const MODELS = Prisma.ModelName

--- a/src/shared/logging.util.ts
+++ b/src/shared/logging.util.ts
@@ -1,4 +1,4 @@
-import { Prisma } from '@prisma/client'
+import { Prisma } from '../generated/prisma'
 
 function isPrismaKnownRequestError(
   error: unknown,

--- a/src/shared/prisma-exception.filter.ts
+++ b/src/shared/prisma-exception.filter.ts
@@ -5,7 +5,7 @@ import {
   HttpStatus,
   Logger,
 } from '@nestjs/common'
-import { Prisma } from '@prisma/client'
+import { Prisma } from '../generated/prisma'
 
 const prismaErrorClasses = [
   Prisma.PrismaClientKnownRequestError,


### PR DESCRIPTION
## Monorepo prep

Behavior-preserving upstream normalization ahead of the omni monorepo migration.

- Add `output = "../../src/generated/prisma"` to the Prisma `generator client` block (preview features unchanged: `multiSchema`, `prismaSchemaFolder`).
- Gitignore `src/generated/` (the per-package generated client is never committed).
- Rewrite the bare `@prisma/client` import specifier to the relative generated path across `src/**` and `seed/**` (16 sites). Subpaths like `@prisma/client/runtime/library` are left untouched.

### Validation
- `npx prisma generate` → emits client to `src/generated/prisma`.
- `npm run build` ✅
- `npm test` ✅ (95/95)

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Import-path and generate-output-only change with no runtime logic edits; main risk is missing `prisma generate` in CI or local dev until docs catch up.
> 
> **Overview**
> Prepares the repo for a monorepo layout by **generating the Prisma client into a package-local directory** instead of the default `node_modules/@prisma/client`.
> 
> The schema’s `generator client` now sets **`output` to `src/generated/prisma`**, and **`.gitignore` ignores `src/generated/`** so the generated client is never committed. Application and seed code that imported **`@prisma/client`** now imports **`../generated/prisma`** (or equivalent relative paths) across Prisma services, people SQL utilities, exception/logging helpers, and seed factories—**no query or API behavior changes**.
> 
> **Operational note:** builds and tests still depend on running **`prisma generate`** (e.g. `npm run generate`) so `src/generated/prisma` exists locally and in CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 451cd9e794e4608714023f11ddb39d1419d8888a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->