### PR TITLE
chore(build): use swc builder for nest build (monorepo prep)

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -35,7 +35,10 @@ ENV PUPPETEER_EXECUTABLE_PATH=/dev/null
 WORKDIR /app
 
 # Install dependencies
-COPY package.json package-lock.json tsconfig.json tsconfig.build.json ./
+# nest-cli.json is required so `nest build` uses the swc builder (flat dist/
+# layout). Without it the build silently falls back to tsc (dist/src/) and the
+# entrypoint's dist/main.js path no longer resolves.
+COPY package.json package-lock.json tsconfig.json tsconfig.build.json nest-cli.json ./
 
 # Copy application source files, prisma files, and seed data
 COPY src/ ./src
@@ -73,6 +76,11 @@ RUN npm ci --only=production --ignore-scripts
 # Copy only necessary files to the runtime image
 COPY --from=builder /app/node_modules/.prisma ./node_modules/.prisma
 COPY --from=builder /app/dist ./dist
+# Prisma client now generates to a per-package output dir (src/generated/prisma)
+# instead of node_modules/.prisma. tsc does not emit these prebuilt JS files or
+# the query-engine binary, so copy them to where the compiled dist code resolves
+# them: dist/src/people/.../*.js require('../../generated/prisma') -> dist/src/generated/prisma.
+COPY --from=builder /app/src/generated/prisma ./dist/src/generated/prisma
 COPY --from=builder /app/prisma ./prisma
 COPY module-alias.js ./
 

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -76,11 +76,6 @@ RUN npm ci --only=production --ignore-scripts
 # Copy only necessary files to the runtime image
 COPY --from=builder /app/node_modules/.prisma ./node_modules/.prisma
 COPY --from=builder /app/dist ./dist
-# Prisma client now generates to a per-package output dir (src/generated/prisma)
-# instead of node_modules/.prisma. tsc does not emit these prebuilt JS files or
-# the query-engine binary, so copy them to where the compiled dist code resolves
-# them: dist/src/people/.../*.js require('../../generated/prisma') -> dist/src/generated/prisma.
-COPY --from=builder /app/src/generated/prisma ./dist/src/generated/prisma
 COPY --from=builder /app/prisma ./prisma
 COPY module-alias.js ./
 

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -35,10 +35,10 @@ ENV PUPPETEER_EXECUTABLE_PATH=/dev/null
 WORKDIR /app
 
 # Install dependencies
-# nest-cli.json is required so `nest build` uses the swc builder (flat dist/
-# layout). Without it the build silently falls back to tsc (dist/src/) and the
-# entrypoint's dist/main.js path no longer resolves.
 COPY package.json package-lock.json tsconfig.json tsconfig.build.json nest-cli.json ./
+# nest-cli.json (above) is required so `nest build` uses the swc builder (flat
+# dist/ layout). Without it the build silently falls back to tsc (dist/src/) and
+# the entrypoint's dist/main.js path no longer resolves.
 
 # Copy application source files, prisma files, and seed data
 COPY src/ ./src

--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -5,4 +5,4 @@ echo "Starting people-api container..."
 echo "Environment: NODE_ENV=${NODE_ENV}"
 
 echo "Starting the application..."
-exec node -r ./dist/src/otel.js dist/src/main.js
+exec node -r ./dist/otel.js dist/main.js

--- a/module-alias.js
+++ b/module-alias.js
@@ -1,5 +1,5 @@
 const moduleAlias = require('module-alias')
 
 moduleAlias.addAliases({
-  'src': __dirname + '/dist/src'
+  'src': __dirname + '/dist'
 })

--- a/nest-cli.json
+++ b/nest-cli.json
@@ -3,6 +3,8 @@
   "collection": "@nestjs/schematics",
   "sourceRoot": "src",
   "compilerOptions": {
+    "builder": "swc",
+    "typeCheck": true,
     "deleteOutDir": true,
     "assets": ["prisma/**/*"],
     "watchAssets": true

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "start:perf-local": "ENV_PATH=.env.perf-local NODE_ENV=perf-local nest start",
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
-    "start:prod": "node -r ./dist/src/otel.js dist/src/main.js",
+    "start:prod": "node -r ./dist/otel.js dist/main.js",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "lint-format": "npm run lint && npm run format",
     "migrate:dev": "node ./scripts/disallow-perf-local.js && npx prisma migrate dev",

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import '../../module-alias'
+import '../module-alias'
 import './configrc'
 import { HttpAdapterHost, NestFactory } from '@nestjs/core'
 import {


### PR DESCRIPTION
## Monorepo prep

Behavior-preserving toolchain convergence with gp-api ahead of the omni monorepo migration.

- Switch the nest build from the default `tsc` builder to **swc** in `nest-cli.json` (people-api already ships `unplugin-swc`/`@swc/core`). Kept a real type-check via `typeCheck: true` so the build still fails on type errors, matching gp-api.
- The swc builder emits a **flat** `dist/` layout (`dist/main.js`) instead of `dist/src/`. Updated the four spots coupled to the old layout to the flat paths (mirroring gp-api):
  - `src/main.ts`: `import '../../module-alias'` → `'../module-alias'`
  - `module-alias.js`: `'src'` alias → `__dirname + '/dist'`
  - `package.json` `start:prod` → `node -r ./dist/otel.js dist/main.js`
  - `deploy/entrypoint.sh` → `node -r ./dist/otel.js dist/main.js`

No `.swcrc` was needed — Nest's swc builder enables decorator metadata by default; DI resolves correctly.

### Validation
- `npm run build` ✅ (`TSC Found 0 issues`, swc compiled 54 files)
- Boot `node dist/main.js` ✅ — full DI graph initializes (App/Prisma/Auth/District modules); only stops on the dummy DB credentials (`P1000`), i.e. no swc/decorator/DI errors.
- `npm test` ✅ (95/95)

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Toolchain and dist path updates only; no app logic, auth, or data-layer changes, with build/test/boot validation described in the PR.
> 
> **Overview**
> Switches **people-api** Nest builds from the default **tsc** compiler to the **swc** builder in `nest-cli.json`, with **`typeCheck: true`** so type errors still fail the build (aligned with gp-api / monorepo prep).
> 
> Because swc emits a **flat** `dist/` tree (`dist/main.js` instead of `dist/src/...`), this PR rewires the few hard-coded paths that assumed the old layout: **`module-alias`** now maps `src` → `dist`, **`src/main.ts`** loads `../module-alias`, and **prod/container** startup (`start:prod`, `deploy/entrypoint.sh`) preloads **`./dist/otel.js`** and runs **`dist/main.js`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 358f65f471c3c1329f93dd4166891e3091baa788. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->