### PR TITLE
fix(deploy): copy generated Prisma client into runtime image

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -74,13 +74,11 @@ COPY package.json package-lock.json ./
 RUN npm ci --only=production --ignore-scripts
 
 # Copy only necessary files to the runtime image
-COPY --from=builder /app/node_modules/.prisma ./node_modules/.prisma
 COPY --from=builder /app/dist ./dist
 # Prisma client now generates to a per-package output dir (src/generated/prisma)
-# instead of node_modules/.prisma. tsc does not emit these prebuilt JS files or
-# the query-engine binary, so copy them to where the compiled dist code resolves
-# them: dist/src/people/.../*.js require('../../generated/prisma') -> dist/src/generated/prisma.
-COPY --from=builder /app/src/generated/prisma ./dist/src/generated/prisma
+# instead of node_modules/.prisma. Copy it to where the compiled dist code
+# resolves it, including the query-engine binary generated for the runtime image.
+COPY --from=builder /app/src/generated/prisma ./dist/generated/prisma
 COPY --from=builder /app/prisma ./prisma
 COPY module-alias.js ./
 


### PR DESCRIPTION
## Summary
- Remove the stale Docker runtime copy from `node_modules/.prisma`, which no longer exists after Prisma client isolation.
- Copy the generated Prisma client into `dist/generated/prisma`, matching the compiled SWC import paths and including the runtime query engine.

## Test plan
- `DATABASE_URL='postgresql://user:pass@localhost:5432/db' npm run generate && npm run build`
- `docker build -f deploy/Dockerfile --build-arg DATABASE_URL='postgresql://user:pass@localhost:5432/db' -t people-api-deploy-smoke .`
- `docker run --rm --entrypoint node people-api-deploy-smoke -e "const fs=require('fs'); const path='./dist/generated/prisma'; const files=fs.readdirSync(path).filter((f)=>f.includes('query')||f.endsWith('.node')); console.log(files.join('\\n')); const { PrismaClient } = require(path); new PrismaClient(); console.log('prisma client loaded');"`

## Context
Failing develop deploy: https://github.com/thegoodparty/people-api/actions/runs/26978523667

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Deploy-only Dockerfile change with no application logic changes; wrong paths would fail at container start rather than silently misbehaving.
> 
> **Overview**
> Fixes the production Docker image so the **isolated Prisma client** (`src/generated/prisma`) is present at runtime after deploy failures on develop.
> 
> The runtime stage **drops** copying `node_modules/.prisma` (no longer used) and **copies** the builder’s generated client to **`dist/generated/prisma`**, aligned with the flat SWC `dist/` layout so compiled imports resolve and the **query engine** binary ships with the image.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8522a77457863f42e84cd1d6d1953b7218eaede. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->